### PR TITLE
fix(docker): Correct dev commands for Nextjs, build before start in prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ echo "\nENCRYPTION_KEY=\"`openssl rand -base64 32`\"" >> .env
 3. Start the app
 
 ```bash
-docker compose up
+docker compose --env-file .env up
 ```
 
 You can now open your browser and go to http://localhost:3000 to connect to the application.
@@ -150,7 +150,7 @@ For now, we are not accepting pull requests from the community, but We are worki
 To start the development environment, simply follow the instructions above to start the app, but change the final commmand to:
 
 ```bash
-docker compose -f docker-compose.dev.yml up
+docker compose -f docker-compose.dev.yml --env-file .env up
 ```
 
 Unlike the production environemnt, this supports hot reload and adds development resources like a test Postgres instance.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ git clone https://github.com/turntable-so/turntable.git
 cd turntable
 
 # Copy .example.env to .env
-cp frontend/.env.example frontend/.env
+cp .env.example .env
 
 # Create a fresh encryption key
 echo "\nENCRYPTION_KEY=\"`openssl rand -base64 32`\"" >> .env

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Turntable is distributed under the AGPLv3 License.
 3. Make sure Git is installed on your machine.
 
 ### Run the app
-To start using Turntable
+To start using Turntable:
 
 1. Clone the repository
 
@@ -104,22 +104,23 @@ git clone https://github.com/turntable-so/turntable.git
 
 # Go to Turntable folder
 cd turntable
+
+# Copy .example.env to .env
+cp frontend/.env.example frontend/.env
+
+# Create a fresh encryption key
+echo "\nENCRYPTION_KEY=\"`openssl rand -base64 32`\"" >> .env
 ```
 
-2. Configure environment variables
-  - Copy the `.env.example` file to `.env`
+2. Configure additional environment variables
+
   - Set any variables (e.g. s3 credentials) you'd like for your environment
   - No environment variables except the `ENCRYPTION_KEY` are required to run the app, but some functionality may be limited (e.g. AI-written documentation)
-  - Crete an encryption key by running the following command:
-
-```bash
-echo "ENCRYPTION_KEY=\"`openssl rand -base64 32`\"" >> .env
-```
 
 3. Start the app
 
 ```bash
-docker compose up --env-file .env
+docker compose up
 ```
 
 You can now open your browser and go to http://localhost:3000 to connect to the application.
@@ -149,7 +150,7 @@ For now, we are not accepting pull requests from the community, but We are worki
 To start the development environment, simply follow the instructions above to start the app, but change the final commmand to:
 
 ```bash
-docker compose -f docker-compose.dev.yml up --env-file .env
+docker compose -f docker-compose.dev.yml up
 ```
 
 Unlike the production environemnt, this supports hot reload and adds development resources like a test Postgres instance.

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -24,7 +24,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-i7pd5iwtuo*0h9je%(n1!u8srlbka$^do)c(#y88h9grhilq3@"
+SECRET_KEY = "django-insecure-i7pd5iwtuo*0h9je%(n1!u8srlbka$^do)c(#y88h9grhilq3@" # oooo?
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -24,7 +24,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-i7pd5iwtuo*0h9je%(n1!u8srlbka$^do)c(#y88h9grhilq3@" # oooo?
+SECRET_KEY = "django-insecure-i7pd5iwtuo*0h9je%(n1!u8srlbka$^do)c(#y88h9grhilq3@"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -48,7 +48,7 @@ services:
     environment:
       DEV: "true"
     volumes:
-      - ./frontend:/code
+      - ./frontend:/
     command: ["pnpm", "dev"]
 
   postgres:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -49,6 +49,7 @@ services:
       DEV: "true"
     volumes:
       - ./frontend:/code
+    command: ["pnpm", "dev"]
 
   postgres:
     extends:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
     build:
       context: frontend
       dockerfile: Dockerfile
-    command: ["pnpm", "start"]
+    command: ["pnpm", "build", "&&", "pnpm", "start"]
     ports:
       - "3000:3000"
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,5 +12,5 @@ RUN npm install -g pnpm
 # Install dependencies
 RUN pnpm install
 
-
+# Expose the application port for Next from the container
 EXPOSE 3000

--- a/frontend/src/components/auth/registration-form.tsx
+++ b/frontend/src/components/auth/registration-form.tsx
@@ -80,13 +80,16 @@ const RegistrationForm = ({invitationCode = ''} : any) => {
             .catch((err) => {
                 console.log("ERROR")
                 console.log(err)
-                setIsLoading(false)
-                if (err.json.email) {
+                if (err?.json?.email) {
                     setError("email", { type: "server", message: err.json.email })
                 }
-                if (err.json.password) {
+                if (err?.json?.password) {
                     setError("password", { type: "server", message: err.json.password })
                 }
+                if (err instanceof TypeError && err.message === "Failed to fetch") {
+                    setFormRespError("Unable to connect to the server. Please try again.")
+                }
+                setIsLoading(false)
             });
     };
 


### PR DESCRIPTION
Saw the repo and wanted to poke around a bit. Didn't manage to get things fully set up even in dev but made some progress and took some friction notes along the way.

This PR patches the docker compose in dev and prod to include correct nextjs build and dev-start commands, and avoid typesafety errors bubbling on the frontend for a clearer error if auth isn't fully wired up correctly.