### PR TITLE
added coercion for port number

### DIFF
--- a/frontend/src/components/connections/forms/postgres-form.tsx
+++ b/frontend/src/components/connections/forms/postgres-form.tsx
@@ -24,7 +24,7 @@ const FormSchema = z.object({
     host: z.string().min(1, {
         message: "Hostname account can't be empty",
     }),
-    port: z.number().min(1, {
+    port: z.coerce.number().min(1, {
         message: "Port can't be empty",
     }),
     database: z.string().min(1, {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1c73981e8ac5877ce308d59cc36cf421991cf1f8  | 
|--------|--------|

### Summary:
Added coercion for the `port` field in `FormSchema` in `frontend/src/components/connections/forms/postgres-form.tsx` to ensure input is converted to a number.

**Key points**:
- Updated `frontend/src/components/connections/forms/postgres-form.tsx`.
- Modified `FormSchema` to use `z.coerce.number()` for `port` field.
- Ensures `port` input is coerced to a number, handling string inputs.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->