### PR TITLE
ENG-1130-ENG-1127 fix UI in linage

### DIFF
--- a/frontend/src/components/lineage/ColumnLineageNode.tsx
+++ b/frontend/src/components/lineage/ColumnLineageNode.tsx
@@ -268,7 +268,7 @@ function LineageNode({ id, data, yPos }: any) {
       <div
         className={`cursor-pointer border-2 font-mono shadow-lg text-[12px] text-black rounded-md
         border-solid ${isActiveResource ? "border-blue-400" : "border-gray-300"}
-        bg-muted w-72 max-h-120 overflow-y-scroll overflow-x-hidden relative
+        bg-muted w-72 max-h-72 overflow-y-scroll overflow-x-hidden relative
         ${columnsToDisplay.length > 10 ? "nowheel" : ""}
         ${
           selectedColumn != null &&

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -349,7 +349,7 @@ export function getAssetIcon(type: string, resourceType?: string) {
     return <MetabaseIcon />
   }
   if (type === 'source') {
-    return <div className='mr-1'><BigQueryLogo /></div>
+    return <div className='mr-1 flex flex-col'><BigQueryLogo />  <DbtLogo /></div>
   } else {
     return (
       <div className="mr-1">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 955123a921ca371bbab27054de8ca34bdb7719af  | 
|--------|--------|

### Summary:
This PR reduces the maximum height of a UI element in `ColumnLineageNode.tsx` and adds a `DbtLogo` to the asset icon for 'source' types in `utils.tsx`.

**Key points**:
- In `frontend/src/components/lineage/ColumnLineageNode.tsx`, reduced `max-h` from `120` to `72` for a UI element.
- In `frontend/src/lib/utils.tsx`, modified `getAssetIcon` to include `DbtLogo` alongside `BigQueryLogo` for 'source' type resources.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->