### PR TITLE
Adjust env variable injection approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ cd turntable
 ```
 
 2. Configure environment variables
-   Create a `.env` file in the root of the project by running the following command
+   Create a `.env.local` file in the root of the project by running the following command
 
 **MacOS or Linux**
 
@@ -149,7 +149,7 @@ To start the app you have two choices:
 Run the following command:
 
 ```bash
-(source .env && docker compose up --build)
+docker compose --env-file .env.local up --build
 ```
 
 Once the docker build is complete (a few minutes), you will see a line in the terminal like this: 'The app is ready! Visit http://localhost:3000/ to get started'. Once you do, open your browser and go to http://localhost:3000 to see the app running. Signup with a username and password to start using the app.
@@ -159,7 +159,7 @@ Once the docker build is complete (a few minutes), you will see a line in the te
 If you'd like to also see the product with a demo postgres, dbt project, and metabase already connected, run:
 
 ```bash
-(source .env && docker compose -f docker-compose.demo.yml up --build)
+docker compose --env-file .env.local -f docker-compose.demo.yml up --build
 ```
 
 Once the docker build is complete (longer than above, usually 5+ minutes), you will see a line in the terminal like this: 'The app is ready! Visit http://localhost:3000/ to get started'. Once you do, open your browser and go to http://localhost:3000 to see the app running. The demo resources can be found in an account with user `dev@turntable.so` and password `mypassword`. Login with these credentials to see the demo resources, with associated lineage and asset viewer. If you'd like to start from a blank slate on this instance, simply sign up with a different email.
@@ -191,7 +191,7 @@ For now, we are not accepting pull requests from the community, but We are worki
 To start the development environment, simply follow the instructions above to start the app, but change the final commmand to:
 
 ```bash
-(source .env && docker compose -f docker-compose.dev.yml up --build)
+docker compose -f docker-compose.dev.yml --env-file .env.local up --build
 ```
 
 Unlike the production environemnt, this supports hot reload. It also includes the demo resources described above.

--- a/generate_keys.ps1
+++ b/generate_keys.ps1
@@ -1,20 +1,20 @@
-# Generate a random base64 encryption key and append to .env file
+# Generate a random base64 encryption key and append to .env.local file
 $byteArray = New-Object 'System.Byte[]' (32)
 (New-Object System.Security.Cryptography.RNGCryptoServiceProvider).GetBytes($byteArray)
 $encryptionKey = [Convert]::ToBase64String($byteArray)
-Set-Content -Path ".env" -Value "ENCRYPTION_KEY='$encryptionKey'"
+Set-Content -Path ".env.local" -Value "ENCRYPTION_KEY='$encryptionKey'"
 
-# Generate a random base64 nextauth secret and append to .env file
+# Generate a random base64 nextauth secret and append to .env.local file
 $byteArray2 = New-Object 'System.Byte[]' (32)
 (New-Object System.Security.Cryptography.RNGCryptoServiceProvider).GetBytes($byteArray2)
 $nextAuthSecret = [Convert]::ToBase64String($byteArray2)
-Add-Content -Path ".env" -Value "NEXTAUTH_SECRET='$nextAuthSecret'"
+Add-Content -Path ".env.local" -Value "NEXTAUTH_SECRET='$nextAuthSecret'"
 
-# Generate a random 50 character string and append to .env file
+# Generate a random 50 character string and append to .env.local file
 $chars = @(
     'a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z',
     '0','1','2','3','4','5','6','7','8','9',
     '!','@','#','$','%','^','&','*','(',')','-','=','_','+'
 )
 $djangoSecretKey = -join (1..50 | ForEach-Object { $chars[(Get-Random -Minimum 0 -Maximum $chars.Length)] })
-Add-Content -Path ".env" -Value "DJANGO_SECRET_KEY='$djangoSecretKey'"
+Add-Content -Path ".env.local" -Value "DJANGO_SECRET_KEY='$djangoSecretKey'"

--- a/generate_keys.sh
+++ b/generate_keys.sh
@@ -2,13 +2,13 @@
 platform=$(uname)
 
 if [[ "$platform" == "Darwin" ]]; then
-    echo "ENCRYPTION_KEY=\"`openssl rand -base64 32`\"" >> .env
-    echo "NEXTAUTH_SECRET=\"`openssl rand -base64 32`\"" >> .env
-    echo "DJANGO_SECRET_KEY=\"`env LC_ALL=C tr -dc 'a-z0-9!@#$%^&*(-_=+)' < /dev/urandom | head -c 50`\"" >> .env
+    echo "ENCRYPTION_KEY=\"`openssl rand -base64 32`\"" >> .env.local
+    echo "NEXTAUTH_SECRET=\"`openssl rand -base64 32`\"" >> .env.local
+    echo "DJANGO_SECRET_KEY=\"`env LC_ALL=C tr -dc 'a-z0-9!@#$%^&*(-_=+)' < /dev/urandom | head -c 50`\"" >> .env.local
 elif [[ "$platform" == "Linux" ]]; then
-    echo "ENCRYPTION_KEY=\"`openssl rand -base64 32`\"" >> .env
-    echo "NEXTAUTH_SECRET=\"`openssl rand -base64 32`\"" >> .env
-    echo "DJANGO_SECRET_KEY=\"`< /dev/urandom tr -dc 'a-z0-9!@#$%^&*(-_=+)' | head -c 50`\"" >> .env
+    echo "ENCRYPTION_KEY=\"`openssl rand -base64 32`\"" >> .env.local
+    echo "NEXTAUTH_SECRET=\"`openssl rand -base64 32`\"" >> .env.local
+    echo "DJANGO_SECRET_KEY=\"`< /dev/urandom tr -dc 'a-z0-9!@#$%^&*(-_=+)' | head -c 50`\"" >> .env.local
 else
     echo "Unsupported platform: $platform"
 fi


### PR DESCRIPTION
core issue seemed to be with docker compose's default use of the `.env` file. Use `.env.local` to prevent collisions.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d7c225880dbd50618e8ddc0f48239a289d0df5df  | 
|--------|--------|

### Summary:
This PR changes environment variable handling from `.env` to `.env.local` to avoid Docker Compose conflicts, updating `README.md` and key generation scripts accordingly.

**Key points**:
- Updated `README.md` to instruct creating `.env.local` instead of `.env`.
- Modified Docker Compose commands in `README.md` to use `--env-file .env.local`.
- Changed `generate_keys.ps1` to append keys to `.env.local` instead of `.env`.
- Changed `generate_keys.sh` to append keys to `.env.local` instead of `.env`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->