### PR TITLE
feature: add export command

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,8 @@
 .ruff_cache
 .*venv/
 .env
+private/
+exports/
 
 # dependencies
 /node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,7 +9,6 @@
 .*venv/
 .env
 private/
-exports/
 
 # dependencies
 /node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 .*env
 .hatchetconfig
 private/
-exports/
 
 # dependencies
 /node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .*env
 .hatchetconfig
 private/
+exports/
 
 # dependencies
 /node_modules

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,116 @@
+# Hidden files and folders]
+.*
+.*/
+!.gitignore
+
+# Duckdb files with a few exceptions
+*.duckdb
+!test.duckdb
+!fixtures/datahub_dbs/postgres.duckdb
+!fixtures/datahub_dbs/metabase.duckdb
+*.duckdb.tmp/
+*.duckdb.wal
+
+# export folder
+exports/
+
+# DS Store files
+.DS_Store
+
+# Profiling info
+scripts/debug/profile/*
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+# lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Scrapy stuff:
+.scrapy
+
+# PyBuilder
+.pybuilder/
+target/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+

--- a/backend/app/management/commands/export.py
+++ b/backend/app/management/commands/export.py
@@ -1,0 +1,40 @@
+import os
+import shutil
+import time
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+from app.models import Resource
+
+
+class Command(BaseCommand):
+    help = "Export db data and datahub dbs as a zip in exports folder"
+
+    def handle(self, *args, **kwargs):
+        base_dir = "fixtures/datahub_dbs"
+        # get db dump
+        output_file = os.path.join(base_dir, "dumpdata.json")
+        with open(output_file, "w") as f:
+            call_command("dumpdata", "--format=json", stdout=f)
+
+        # get datahub db
+        for resource in Resource.objects.all():
+            if not resource.datahub_db:
+                continue
+            with resource.datahub_db.open("rb") as f:
+                db_save_path = os.path.join(
+                    base_dir, f"{resource.id}_{resource.details.subtype}.duckdb"
+                )
+                with open(db_save_path, "wb") as f2:
+                    f2.write(f.read())
+
+        # package everything as a zip
+        export_dir = "exports/"
+        os.makedirs(export_dir, exist_ok=True)
+        zip_path = f"{round(time.time())}_db_export"
+        shutil.make_archive(zip_path, "zip", base_dir)
+        shutil.move(f"{zip_path}.zip", export_dir)
+
+        # delete dumpdata.json
+        os.remove(output_file)

--- a/backend/app/management/commands/tests/test_export.py
+++ b/backend/app/management/commands/tests/test_export.py
@@ -1,0 +1,19 @@
+import os
+import time
+
+import pytest
+from django.core.management import call_command
+
+
+@pytest.mark.django_db
+def test_data_export():
+    call_command("export")
+
+    ## check if a file exists
+    dir = "exports/"
+    relevant_file_times = [
+        os.path.getctime(f"{dir}{f}") for f in os.listdir(dir) if f.endswith(".zip")
+    ]
+    assert any(
+        [time.time() - t < 5 for t in relevant_file_times]
+    ), "Exported file not found in exports folder"

--- a/backend/fixtures/test_resources/jaffle_shop/.gitignore
+++ b/backend/fixtures/test_resources/jaffle_shop/.gitignore
@@ -1,0 +1,3 @@
+target/
+logs/
+dbt_packages/

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -138,6 +138,7 @@ packages = ["."]
 testpaths = [
     "app/services/tests",
     "app/core/tests",
+    "app/management/commands/tests",
     "vinyl/tests",
     "ai/tests",
     "workflows/tests",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c505af574dc4fed764d7b0d93abfb30ded7ee48e  | 
|--------|--------|

feat: add export command for database and datahub data

### Summary:
Adds an export command for database and datahub data with tests and configuration updates.

**Key points**:
- **Feature**: Adds `export` command in `export.py` to export database and datahub data as a zip file in `exports/`. Uses `dumpdata` to export database data to `dumpdata.json` and includes datahub databases from `Resource` model. Zips the exported data and moves it to `exports/` directory.
- **Testing**: Adds `test_export.py` to test the `export` command, ensuring a zip file is created in `exports/`.
- **Configuration**: Updates `.dockerignore` to ignore `private/` and `exports/` directories. Adds `app/management/commands/tests` to `testpaths` in `pyproject.toml`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->