### PR TITLE
eng-1164: fix refresh token in fe

### DIFF
--- a/frontend/src/app/fetcher.ts
+++ b/frontend/src/app/fetcher.ts
@@ -13,12 +13,13 @@ const fetchWithAuth = async (url: string, options = {} as any) => {
     if (!(options?.body instanceof FormData)) {
         headers["Content-Type"] = "application/json";
     }
+
     const response = await fetch(url, { ...options, headers });
+
     if (response.status === 401) {
         try {
-            const { access, refresh } = await (await handleJWTRefresh()).json() as any;
+            const { access } = await (await handleJWTRefresh(options?.cookies)).json() as any;
             storeToken(access, "access");
-            storeToken(refresh, "refresh"); // Store the new refresh token
 
             const retryHeaders = {
                 ...headers,

--- a/frontend/src/app/url.ts
+++ b/frontend/src/app/url.ts
@@ -1,3 +1,3 @@
 export default function getUrl() {
-    return process.env.NEXT_PUBLIC_BACKEND_HOST || (typeof window === "undefined" ? "http://api:8000" : "http://localhost:8000")
+    return (typeof window === "undefined" ? "http://api:8000" : "http://localhost:8000")
 } 

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -77,8 +77,8 @@ const logout = () => {
  * Refreshes the JWT token using the stored refresh token.
  * @returns {Promise} A promise that resolves with the new access token.
  */
-const handleJWTRefresh = () => {
-    const refreshToken = getToken("refresh");
+const handleJWTRefresh = (cookies:any = null) => {
+    const refreshToken = getToken("refresh", cookies);
     return api.post({ refresh: refreshToken }, "/auth/jwt/refresh");
 };
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit af5214a41dc2ccb57958aa7e90a130525c81e2aa  | 
|--------|--------|

fix: remove refresh token storage in frontend

### Summary:
Remove refresh token storage in `fetchWithAuth` and update `handleJWTRefresh` to accept cookies in `auth.ts`.

**Key points**:
- **Behavior**:
  - `fetchWithAuth` in `fetcher.ts` no longer stores the refresh token, only the access token.
  - `handleJWTRefresh` in `auth.ts` now accepts `cookies` as an optional parameter.
- **Functions**:
  - `getUrl` in `url.ts` removes the check for `process.env.NEXT_PUBLIC_BACKEND_HOST`.
- **Misc**:
  - Removed storing of refresh token in `fetchWithAuth` retry logic.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->

The following video is after 15 minutes of no action on the fe

https://github.com/user-attachments/assets/747df264-7338-4c56-ba41-4ad225c5ce78



