### PR TITLE
fix: fix last synced

### DIFF
--- a/frontend/src/app/connections/connection-layout.tsx
+++ b/frontend/src/app/connections/connection-layout.tsx
@@ -113,9 +113,9 @@ export default function ConnectionLayout({
           <Card className="px-5 py-6 flex justify-between items-center">
             <div>
               <CardTitle>Sync Connection</CardTitle>
-              <CardDescription className="py-1">{`Last synced ${dayjs(
-                resource.updated_at
-              ).fromNow()} `}</CardDescription>
+              <CardDescription className="py-1">{resource.last_synced ? `Last synced ${dayjs(
+                resource.last_synced
+              ).fromNow()} ` : ''}</CardDescription>
             </div>
             <div className="flex justify-end items-center space-x-2">
               <div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix display logic for last synced time in `connection-layout.tsx` to handle undefined `resource.last_synced`.
> 
>   - **Behavior**:
>     - In `connection-layout.tsx`, update `CardDescription` to check if `resource.last_synced` exists before displaying the last synced time.
>     - If `resource.last_synced` is undefined, display an empty string instead of a time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 2e1623a70159999317fb348e1c98319e5d88f0a8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->