### PR TITLE
Adds shared volume for api and worker

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -16,7 +16,7 @@ services:
       /bin/sh -c "
       python manage.py migrate &&
       python manage.py seed_data &&
-      uvicorn api.asgi:application --host 0.0.0.0 --port 8000"   
+      uvicorn api.asgi:application --host 0.0.0.0 --port 8000"
     depends_on:
       ensure_populate_test_db:
         condition: service_completed_successfully
@@ -27,7 +27,7 @@ services:
     extends:
       file: docker-compose.yml
       service: web
-  
+
   redis:
     extends:
       file: docker-compose.yml
@@ -143,6 +143,7 @@ volumes:
   hatchet_credentials_handoff:
   postgres_test_db_data:
   frontend_data:
+  code_repos:
 
 networks:
   default:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -146,6 +146,7 @@ volumes:
   hatchet_credentials_handoff:
   postgres_test_db_data:
   frontend_data:
+  code_repos:
 
 networks:
   default:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -105,7 +105,7 @@ services:
       file: docker-compose.dev-internal.yml
       service: createbuckets
     entrypoint: ["echo", "Service createbuckets disabled"]
-  
+
   minio:
     extends:
       file: docker-compose.dev-internal.yml
@@ -132,14 +132,12 @@ services:
     entrypoint: ["echo", "Service setup-hatchet disabled"]
     restart: no
 
-  
   create_hatchet_db:
     extends:
       file: docker-compose.dev-internal.yml
       service: create_hatchet_db
     entrypoint: ["echo", "Service create_hatchet_db disabled"]
     restart: no
-
 
 volumes:
   postgres_data:
@@ -149,7 +147,7 @@ volumes:
   hatchet_credentials_handoff:
   postgres_test_db_data:
   frontend_data:
-
+  code_repos:
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,7 @@ x-common-backend: &common-backend
       condition: service_healthy
   volumes:
     - .hatchetconfig:/.hatchetconfig
+    - code_repos:/data/code
 
 name: turntable
 
@@ -111,7 +112,7 @@ services:
     command: >
       /bin/sh -c "
       python manage.py migrate &&
-      uvicorn api.asgi:application --host 0.0.0.0 --port 8000"    
+      uvicorn api.asgi:application --host 0.0.0.0 --port 8000"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/healthcheck/health/"]
       interval: 30s
@@ -133,7 +134,6 @@ services:
         condition: service_started
     environment:
       <<: [*next-credentials, *telemetry-credentials]
-
 
   postgres:
     image: pgvector/pgvector:pg16
@@ -264,6 +264,7 @@ volumes:
   hatchet_credentials_handoff:
   postgres_test_db_data:
   frontend_data:
+  code_repos:
 
 networks:
   default:


### PR DESCRIPTION
Mounts a shared volume for code repos in both `api` and `worker` under `/data/code`

How I tested that this works:
exec api bash -> touch foobar.txt -> ls /data/code -> see foobar.txt
exec api worker -> ls /data/code -> see foobar.txt
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add shared `code_repos` volume for `api` and `worker` services across all environments.
> 
>   - **Volumes**:
>     - Add `code_repos` volume to `docker-compose.yml`, `docker-compose.demo.yml`, `docker-compose.dev.yml`, and `docker-compose.staging.yml`.
>     - Mount `code_repos` to `/data/code` in `api` and `worker` services.
>   - **Testing**:
>     - Verified shared volume by creating a file in `api` and accessing it from `worker`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 8729f6446e2b1b6764bd01215cf14edbfb3a77a2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->