### PR TITLE
Justin/eng-1194-add-internal-test-repo

### DIFF
--- a/backend/app/management/commands/seed_data_staging.py
+++ b/backend/app/management/commands/seed_data_staging.py
@@ -6,6 +6,7 @@ from fixtures.staging_env import (
     group_1,
     group_2,
     group_3,
+    group_4,
     group_5,
     group_6,
 )
@@ -16,12 +17,11 @@ class Command(BaseCommand):
 
     @transaction.atomic
     def handle(self, *args, **kwargs):
-        pass
-
         user = create_user()
         group_1(user)
         group_2(user)
         group_3(user)
+        group_4(user)
         group_5(user)
         group_6(user)
         self.stdout.write(

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -115,6 +115,11 @@ def remote_bigquery(user):
 
 
 @pytest.fixture
+def remote_powerbi(user):
+    return group_4(user)[1]
+
+
+@pytest.fixture
 def remote_redshift(user):
     return group_5(user)[0]
 
@@ -163,6 +168,11 @@ def use_cache(request):
     return request.config.getoption("--use_cache")
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def force_isolate(monkeypatch):
     monkeypatch.setenv("FORCE_ISOLATE", "true")
+
+
+@pytest.fixture
+def bypass_hatchet(monkeypatch):
+    monkeypatch.setenv("BYPASS_HATCHET", "true")

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -15,7 +15,7 @@ from fixtures.local_env import (
     create_repository_n,
     create_ssh_key_n,
 )
-from fixtures.staging_env import group_2, group_3, group_4, group_5, group_6
+from fixtures.staging_env import group_1, group_2, group_3, group_4, group_5, group_6
 from workflows.metadata_sync import MetadataSyncWorkflow
 from workflows.utils.debug import ContextDebugger
 
@@ -115,18 +115,18 @@ def remote_bigquery(user):
 
 
 @pytest.fixture
-def remote_powerbi(user):
-    return group_4(user)[1]
-
-
-@pytest.fixture
 def remote_redshift(user):
     return group_5(user)[0]
 
 
 @pytest.fixture
-def turntable_dbt(user):
+def internal_bigquery(user):
     return group_6(user)[0]
+
+
+@pytest.fixture
+def internal_bigquery_deprecated(user):
+    return group_1(user)[0]
 
 
 @pytest.fixture
@@ -163,11 +163,6 @@ def use_cache(request):
     return request.config.getoption("--use_cache")
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def force_isolate(monkeypatch):
     monkeypatch.setenv("FORCE_ISOLATE", "true")
-
-
-@pytest.fixture
-def bypass_hatchet(monkeypatch):
-    monkeypatch.setenv("BYPASS_HATCHET", "true")

--- a/backend/fixtures/staging_env.py
+++ b/backend/fixtures/staging_env.py
@@ -81,12 +81,10 @@ def create_bigquery_n(workspace, n):
     assert resource_name, f"must provide BIGQUERY_{n}_RESOURCE_NAME to use this test"
     # assert schema_include, f"must provide BIGQUERY_{n}_SCHEMA_INCLUDE to use this test"
 
-    try:
-        resource = Resource.objects.get(workspace=workspace, type=ResourceType.DB)
-    except Resource.DoesNotExist:
-        resource = Resource.objects.create(
-            workspace=workspace, type=ResourceType.DB, name=resource_name
-        )
+    resource, _ = Resource.objects.get_or_create(
+        workspace=workspace, type=ResourceType.DB, name=resource_name
+    )
+
     if not hasattr(resource, "details") or not isinstance(
         resource.details, BigqueryDetails
     ):
@@ -114,12 +112,11 @@ def create_snowflake_n(workspace, n):
     assert warehouse, f"must provide SNOWFLAKE_{n}_WAREHOUSE to use this test"
     assert role, f"must provide SNOWFLAKE_{n}_ROLE to use this test"
     assert resource_name, f"must provide SNOWFLAKE_{n}_RESOURCE_NAME to use this test"
-    try:
-        resource = Resource.objects.get(workspace=workspace, type=ResourceType.DB)
-    except Resource.DoesNotExist:
-        resource = Resource.objects.create(
-            workspace=workspace, type=ResourceType.DB, name=resource_name
-        )
+
+    resource, _ = Resource.objects.get_or_create(
+        workspace=workspace, type=ResourceType.DB, name=resource_name
+    )
+
     if not hasattr(resource, "details") or not isinstance(
         resource.details, SnowflakeDetails
     ):
@@ -145,12 +142,9 @@ def create_databricks_n(workspace, n):
     assert http_path, f"must provide DATABRICKS_{n}_HTTP_PATH to use this test"
     assert resource_name, f"must provide DATABRICKS_{n}_RESOURCE_NAME to use this test"
 
-    try:
-        resource = Resource.objects.get(workspace=workspace, type=ResourceType.DB)
-    except Resource.DoesNotExist:
-        resource = Resource.objects.create(
-            workspace=workspace, type=ResourceType.DB, name=resource_name
-        )
+    resource, _ = Resource.objects.get_or_create(
+        workspace=workspace, type=ResourceType.DB, name=resource_name
+    )
 
     if not hasattr(resource, "details") or not isinstance(
         resource.details, DatabricksDetails
@@ -182,12 +176,9 @@ def create_redshift_n(workspace: Workspace, n):
     assert serverless, f"must provide REDSHIFT_{n}_SERVERLESS to use this test"
     assert resource_name, f"must provide REDSHIFT_{n}_RESOURCE_NAME to use this test"
 
-    try:
-        resource = Resource.objects.get(workspace=workspace, type=ResourceType.DB)
-    except Resource.DoesNotExist:
-        resource = Resource.objects.create(
-            workspace=workspace, type=ResourceType.DB, name=resource_name
-        )
+    resource, _ = Resource.objects.get_or_create(
+        workspace=workspace, type=ResourceType.DB, name=resource_name
+    )
 
     if not hasattr(resource, "details") or not isinstance(
         resource.details, RedshiftDetails
@@ -253,7 +244,7 @@ def create_looker_n(workspace, n, git_repo: Repository | None = None):
 
     looker_secret_json = json.loads(looker_secret)
 
-    looker, _ = Resource.objects.update_or_create(
+    looker, _ = Resource.objects.get_or_create(
         name=resource_name, type=ResourceType.BI, workspace=workspace
     )
     if not hasattr(looker, "details") or not isinstance(looker.details, LookerDetails):
@@ -280,12 +271,9 @@ def create_tableau_n(workspace, n):
     assert password, f"must provide TABLEAU_{n}_PASSWORD to use this test"
     assert resource_name, f"must provide TABLEAU_{n}_RESOURCE_NAME to use this test"
 
-    try:
-        resource = Resource.objects.get(workspace=workspace, type=ResourceType.BI)
-    except Resource.DoesNotExist:
-        resource = Resource.objects.create(
-            workspace=workspace, type=ResourceType.BI, name=resource_name
-        )
+    resource, _ = Resource.objects.get_or_create(
+        workspace=workspace, type=ResourceType.BI, name=resource_name
+    )
 
     if not hasattr(resource, "details") or not isinstance(
         resource.details, TableauDetails
@@ -313,12 +301,9 @@ def create_powerbi_n(workspace, n):
     assert client_secret, f"must provide POWERBI_{n}_CLIENT_SECRET to use this test"
     assert tenant_id, f"must provide POWERBI_{n}_TENANT_ID to use this test"
 
-    try:
-        resource = Resource.objects.get(workspace=workspace, type=ResourceType.BI)
-    except Resource.DoesNotExist:
-        resource = Resource.objects.create(
-            workspace=workspace, type=ResourceType.BI, name=resource_name
-        )
+    resource, _ = Resource.objects.get_or_create(
+        workspace=workspace, type=ResourceType.BI, name=resource_name
+    )
 
     if not hasattr(resource, "details") or not isinstance(
         resource.details, PowerBIDetails


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `group_4` to data seeding and use `get_or_create` for resource management in `staging_env.py`.
> 
>   - **Behavior**:
>     - Add `group_4` to `handle()` in `seed_data_staging.py` for seeding data.
>     - Add `internal_bigquery_deprecated` fixture in `conftest.py` using `group_1`.
>   - **Resource Management**:
>     - Replace manual exception handling with `get_or_create` for resources in `staging_env.py`.
>   - **Fixtures**:
>     - Import `group_1` in `conftest.py` for fixture setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for cab5346e2761ef70225c41558cfa6d8032a842be. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->