### PR TITLE
fix: command panel height

### DIFF
--- a/frontend/src/components/editor/bottom-panel.tsx
+++ b/frontend/src/components/editor/bottom-panel.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/components/ui/table";
 import { AgGridReact } from "ag-grid-react";
 import {
-  CircleX as CircleXIcon,
   Loader2,
   Network,
   Play,

--- a/frontend/src/components/editor/bottom-panel.tsx
+++ b/frontend/src/components/editor/bottom-panel.tsx
@@ -17,7 +17,7 @@ import {
   Table as TableIcon,
   Terminal as TerminalIcon,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { Fragment } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { Panel, PanelResizeHandle } from "react-resizable-panels";
@@ -101,10 +101,8 @@ export default function BottomPanel({
     }
   }, [activeFile, activeTab, fetchFileBasedLineage]);
 
-  const {
-    ref: bottomPanelRef,
-    height: bottomPanelHeight,
-  } = useResizeObserver();
+  const { ref: bottomPanelRef, height: bottomPanelHeight } =
+    useResizeObserver();
 
   return (
     <Fragment>

--- a/frontend/src/components/editor/bottom-panel.tsx
+++ b/frontend/src/components/editor/bottom-panel.tsx
@@ -103,7 +103,6 @@ export default function BottomPanel({
 
   const {
     ref: bottomPanelRef,
-    width: bottomPanelWidth,
     height: bottomPanelHeight,
   } = useResizeObserver();
 

--- a/frontend/src/components/editor/command-panel/command-panel-content.tsx
+++ b/frontend/src/components/editor/command-panel/command-panel-content.tsx
@@ -8,9 +8,7 @@ export default function CommandPanelContent({
   bottomPanelHeight,
 }: { bottomPanelHeight: number | undefined }) {
   const { commandHistory } = useCommandPanelContext();
-  const { ref: headerRef, height: headerHeight } = useResizeObserver();
-  const componentHeight = (bottomPanelHeight || 0) - (headerHeight || 40) - 48;
-  console.log({ bottomPanelHeight, headerHeight, componentHeight });
+  const componentHeight = (bottomPanelHeight || 0) - 48;
 
   return (
     <div

--- a/frontend/src/components/editor/command-panel/command-panel-content.tsx
+++ b/frontend/src/components/editor/command-panel/command-panel-content.tsx
@@ -8,7 +8,7 @@ export default function CommandPanelContent({
   bottomPanelHeight,
 }: { bottomPanelHeight: number | undefined }) {
   const { commandHistory } = useCommandPanelContext();
-  const componentHeight = (bottomPanelHeight || 0) - 48;
+  const componentHeight = (bottomPanelHeight || 500) - 96;
 
   return (
     <div

--- a/frontend/src/components/editor/command-panel/command-panel-content.tsx
+++ b/frontend/src/components/editor/command-panel/command-panel-content.tsx
@@ -1,4 +1,3 @@
-import useResizeObserver from "use-resize-observer";
 import CommandLog from "./command-log";
 import { useCommandPanelContext } from "./command-panel-context";
 import CommandPanelInput from "./command-panel-input";

--- a/frontend/src/components/editor/command-panel/command-panel-content.tsx
+++ b/frontend/src/components/editor/command-panel/command-panel-content.tsx
@@ -9,16 +9,15 @@ export default function CommandPanelContent({
 }: { bottomPanelHeight: number | undefined }) {
   const { commandHistory } = useCommandPanelContext();
   const { ref: headerRef, height: headerHeight } = useResizeObserver();
-  const componentHeight = (bottomPanelHeight || 0) - (headerHeight || 0);
+  const componentHeight = (bottomPanelHeight || 0) - (headerHeight || 40) - 48;
+  console.log({ bottomPanelHeight, headerHeight, componentHeight });
 
   return (
     <div
-      className="flex flex-col p-2 gap-6"
+      className="flex flex-col p-4 gap-4"
       style={{ height: componentHeight }}
     >
-      <div className="flex flex-col gap-2" ref={headerRef}>
-        <CommandPanelInput />
-      </div>
+      <CommandPanelInput />
 
       <div className="flex flex-col flex-1 gap-2 min-h-0">
         {commandHistory.length > 0 ? (
@@ -29,7 +28,6 @@ export default function CommandPanelContent({
             <div className="w-2/3 flex flex-col rounded-md border-2 p-2 overflow-y-auto bg-black text-white">
               <CommandLog bottomPanelHeight={componentHeight} />
             </div>
-            <div className="h-12" />
           </div>
         ) : (
           <p className="text-muted-foreground">No commands run yet</p>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes command panel height calculation and removes unused code in `command-panel-content.tsx` and `bottom-panel.tsx`.
> 
>   - **Behavior**:
>     - Adjusts `componentHeight` calculation in `command-panel-content.tsx` to use a fixed subtraction value of 96 instead of dynamic header height.
>     - Removes unused `headerRef` and associated `useResizeObserver` in `command-panel-content.tsx`.
>   - **Code Cleanup**:
>     - Removes `CircleXIcon` import and `bottomPanelWidth` from `bottom-panel.tsx`.
>     - Removes unused `div` and `ref` in `command-panel-content.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 174b4f53038d8f3a0b6eb707268e1cb5534bc94b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->