### PR TITLE
improvement: parallelize tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: turntable-test-runner
+    runs-on: macos-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: turntable-test-runner
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run tests
         run: |
-          rye run pytest
+          rye run pytest -n auto
         working-directory: backend
         env:
           POSTGRES_DB: mydb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -189,5 +189,10 @@ def bypass_hatchet(monkeypatch):
 
 
 @pytest.fixture
+def vinyl_read_only(monkeypatch):
+    monkeypatch.setenv("VINYL_READ_ONLY", "true")
+
+
+@pytest.fixture
 def enable_django_allow_async_unsafe(monkeypatch):
     monkeypatch.setenv("DJANGO_ALLOW_ASYNC_UNSAFE", "true")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -120,6 +120,7 @@ dev-dependencies = [
     "google-cloud-dataproc>=5.9.3",
     "pytest-django>=4.8.0",
     "harlequin>=1.23.1",
+    "pytest-xdist>=3.6.1",
 ]
 
 [tool.vinyl]

--- a/backend/requirements-dev.lock
+++ b/backend/requirements-dev.lock
@@ -7,7 +7,6 @@
 #   all-features: false
 #   with-sources: false
 #   generate-hashes: false
-#   universal: false
 
 acryl-datahub==0.13.3
 adrf==0.1.6
@@ -184,7 +183,7 @@ django-cors-headers==4.4.0
 django-health-check==3.18.3
 django-invitations==2.1.0
 django-pgbulk==3.0.0
-django-polymorphic @ git+https://github.com/jazzband/django-polymorphic.git@1039f882b99f97bf657bd958c949ee6a3b00377a#egg=django-polymorphic
+django-polymorphic @ git+https://github.com/jazzband/django-polymorphic.git@1039f882b99f97bf657bd958c949ee6a3b00377a
 django-storages==1.14.3
 django-templated-mail==1.1.1
     # via djoser
@@ -208,6 +207,8 @@ email-validator==2.2.0
     # via fastapi
 et-xmlfile==1.1.0
     # via openpyxl
+execnet==2.1.1
+    # via pytest-xdist
 executing==2.0.1
     # via stack-data
 expandvars==0.12.0
@@ -586,8 +587,10 @@ pysocks==1.7.1
 pytest==8.2.2
     # via pytest-asyncio
     # via pytest-django
+    # via pytest-xdist
 pytest-asyncio==0.23.8
 pytest-django==4.8.0
+pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
     # via acryl-datahub
     # via botocore

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -7,7 +7,6 @@
 #   all-features: false
 #   with-sources: false
 #   generate-hashes: false
-#   universal: false
 
 acryl-datahub==0.14.1
 adrf==0.1.7
@@ -172,7 +171,7 @@ django-cors-headers==4.4.0
 django-health-check==3.18.3
 django-invitations==2.1.0
 django-pgbulk==3.0.1
-django-polymorphic @ git+https://github.com/jazzband/django-polymorphic.git@1039f882b99f97bf657bd958c949ee6a3b00377a#egg=django-polymorphic
+django-polymorphic @ git+https://github.com/jazzband/django-polymorphic.git@1039f882b99f97bf657bd958c949ee6a3b00377a
 django-storages==1.14.4
 django-templated-mail==1.1.1
     # via djoser

--- a/backend/vinyl/lib/connect.py
+++ b/backend/vinyl/lib/connect.py
@@ -388,11 +388,18 @@ class DatabaseFileConnector(_FileConnector, _DatabaseConnector):
         # caching ensures we don't attach a database from the same path twice
         name = cls._get_db_name(path)
         if path.endswith(".duckdb") or path.endswith(".db"):
-            conn.attach(path, name, read_only=os.getenv("VINYL_READ_ONLY", False))
+            conn.attach(
+                path,
+                name,
+                read_only=os.getenv("VINYL_READ_ONLY") == "true",
+            )
 
         elif path.endswith(".sqlite"):
             conn.attach(
-                path, name, read_only=os.getenv("VINYL_READ_ONLY", False), sqlite=True
+                path,
+                name,
+                read_only=os.getenv("VINYL_READ_ONLY") == "true",
+                sqlite=True,
             )
 
         else:

--- a/backend/vinyl/tests/test_cli.py
+++ b/backend/vinyl/tests/test_cli.py
@@ -11,7 +11,7 @@ def test_generate_sources():
     assert test() == {}
 
 
-def test_preview_model():
+def test_preview_model(vinyl_read_only):
     import vinyl.cli.preview as preview_cli
 
     preview_cli.preview_model(name="amount_base", twin=False, shutdown_seconds=1)
@@ -19,7 +19,7 @@ def test_preview_model():
     assert True
 
 
-def test_preview_metric():
+def test_preview_metric(vinyl_read_only):
     import vinyl.cli.preview as preview_cli
 
     preview_cli.preview_metric(name="fare_metrics", grain="days=1", shutdown_seconds=1)

--- a/backend/vinyl/tests/test_core.py
+++ b/backend/vinyl/tests/test_core.py
@@ -13,7 +13,7 @@ def test_correct_dataset():
     assert result == 100000
 
 
-def test_fill():
+def test_fill(vinyl_read_only):
     taxi = TaxiSample()
     query = taxi.aggregate(
         by=[taxi.store_and_fwd_flag],
@@ -31,7 +31,7 @@ def test_fill():
     )  # still some nulls left over since can't fill last row
 
 
-def test_metric():
+def test_metric(vinyl_read_only):
     taxi = TaxiSample()
     store = MetricStore()
     store = store.metric(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Parallelize tests using `pytest-xdist` and introduce `vinyl_read_only` fixture for read-only database connections.
> 
>   - **Testing**:
>     - Parallelize tests by adding `-n auto` to `pytest` command in `.github/workflows/test.yml`.
>     - Add `vinyl_read_only` fixture in `conftest.py` to set `VINYL_READ_ONLY` environment variable.
>     - Use `vinyl_read_only` fixture in `test_cli.py` and `test_core.py`.
>   - **Dependencies**:
>     - Add `pytest-xdist>=3.6.1` to `pyproject.toml` and `requirements-dev.lock`.
>   - **Code Changes**:
>     - Update `connect.py` to use `os.getenv("VINYL_READ_ONLY") == "true"` for read-only database connections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 49fab12d213226a8fc035db094ea4f96d54bdda1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->