### PR TITLE
fix render redis url

### DIFF
--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -310,7 +310,7 @@ if os.getenv("LOCAL_REDIS") == "true":
     redis_port = int(os.getenv("REDIS_PORT", 6379))
     redis_url = f"redis://{redis_host}:{redis_port}/"
 else:
-    redis_url = os.getenv("REDIS_URL")
+    redis_url = f"{os.getenv('REDIS_URL')}/" # we add a / cause Render injects the url without a /
     if not redis_url:
         raise ValueError("REDIS_URL is required if LOCAL_REDIS is not set to true")
 

--- a/frontend/src/app/connections/page.tsx
+++ b/frontend/src/app/connections/page.tsx
@@ -274,8 +274,6 @@ const LookerLogo = () => (
 export default async function Page() {
   const resources = (await getResources()) || [];
 
-  console.log(resources);
-
   return (
     <FullWidthPageLayout title="Connections" button={<NewConnectionButton />}>
       {resources.length > 0 ? (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix Redis URL format in `settings.py` and remove unnecessary console log in `page.tsx`.
> 
>   - **Backend**:
>     - Fix Redis URL format in `settings.py` by appending a trailing slash to `REDIS_URL` to ensure compatibility with Render's environment.
>   - **Frontend**:
>     - Remove unnecessary `console.log(resources);` from `page.tsx` to clean up the code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 2ccb3831fd31233a690ef21ff1e91e82d58db4ae. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->