### PR TITLE
fix file exists bug

### DIFF
--- a/backend/app/models/resources.py
+++ b/backend/app/models/resources.py
@@ -83,7 +83,7 @@ def repo_path(
                 temp_project_path = os.path.join(
                     temp_dir, os.path.basename(project_path)
                 )
-                shutil.copytree(project_path, temp_project_path)
+                shutil.copytree(project_path, temp_project_path, dirs_exist_ok=True)
                 yield temp_project_path, None
                 return
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix file exists bug in `repo_path()` by adding `dirs_exist_ok=True` to `shutil.copytree()` in `resources.py`.
> 
>   - **Bug Fix**:
>     - In `repo_path()` in `resources.py`, add `dirs_exist_ok=True` to `shutil.copytree()` to allow copying when destination directory exists.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for ee1fbea5918781e76d2d31471738274e185f9fb6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->