### PR TITLE
[WIP] ENG-1239: Move Asset Search

### DIFF
--- a/frontend/src/app/layout/app-layout.tsx
+++ b/frontend/src/app/layout/app-layout.tsx
@@ -7,6 +7,7 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { useAppContext } from "@/contexts/AppContext";
+import { AssetViewerProvider } from "@/contexts/AssetViewerContext";
 import { usePathname } from "next/navigation";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -72,7 +73,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 "h-[48px] px-2 pl-4 py-1 border-b"
             )}
         /> */}
-      <TopBar />
+        <AssetViewerProvider>
+          <TopBar />
+        </AssetViewerProvider>
 
       <div className="flex w-full">
         {!pathName.includes("/editor") && <SideBar />}

--- a/frontend/src/components/editor/top-bar.tsx
+++ b/frontend/src/components/editor/top-bar.tsx
@@ -14,11 +14,11 @@ import {
   PanelLeftClose,
   PanelRight,
   PanelRightClose,
+  Search,
   Settings,
-  Users,
 } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "../ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import {
@@ -30,6 +30,8 @@ import {
 import WorkspaceSwitcher from "../workspace-switcher";
 import BranchReviewDialog from "./branch-review-dialog";
 import { LocalStorageKeys } from "@/app/constants/local-storage-keys";
+import { useAssets } from "@/contexts/AssetViewerContext";
+import { Input } from "../ui/input";
 
 const clearEditorCache = () => {
   localStorage.removeItem(LocalStorageKeys.activeFile);
@@ -42,6 +44,23 @@ const clearEditorCache = () => {
 const AppContent = () => {
   const { appSidebarCollapsed } = useLayoutContext();
   const { user, logout } = useSession();
+
+  const { query, setQuery, assets, submitSearch } =
+    useAssets();
+
+  useEffect(() => {
+    submitSearch();
+  }, []);
+
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      submitSearch();
+    }
+  };
+
+
+
   return (
     <div
       className={cn(
@@ -54,7 +73,21 @@ const AppContent = () => {
       >
         <WorkspaceSwitcher isCollapsed={appSidebarCollapsed} />
       </div>
-      <Popover>
+      <div className="flex flex-row justify-between w-full items-center">
+      <div className="flex items-center">
+              <div className="relative w-full">
+                <Search className="size-4 absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
+                <Input
+                  autoFocus
+                  placeholder="Search assets"
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  onKeyDown={handleKeyDown}
+                  className="h-10 w-full pl-10"
+                />
+              </div>
+            </div>
+        <Popover>
         <PopoverTrigger asChild className="w-full">
           <Button
             variant="ghost"
@@ -68,7 +101,7 @@ const AppContent = () => {
               </AvatarFallback>
             </Avatar>
             <ChevronDown className="w-3 h-3" />
-          </Button>
+            </Button>
         </PopoverTrigger>
         <PopoverContent
           side="bottom"
@@ -85,6 +118,9 @@ const AppContent = () => {
           </Button>
         </PopoverContent>
       </Popover>
+
+      </div>
+      {/* Add search bar here */}
     </div>
   );
 };

--- a/frontend/src/components/ui/data-table-toolbar.tsx
+++ b/frontend/src/components/ui/data-table-toolbar.tsx
@@ -3,30 +3,9 @@
 import { Cross2Icon } from "@radix-ui/react-icons";
 import type { Table } from "@tanstack/react-table";
 
-import { Input } from "@/components/ui/input";
-
-import { CheckIcon, PlusCircledIcon } from "@radix-ui/react-icons";
-import { Column } from "@tanstack/react-table";
 import type * as React from "react";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
-} from "@/components/ui/command";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { Separator } from "@/components/ui/separator";
-import { cn } from "@/lib/utils";
 
 import { DropdownMenuTrigger } from "@radix-ui/react-dropdown-menu";
 import { MixerHorizontalIcon } from "@radix-ui/react-icons";
@@ -39,8 +18,6 @@ import {
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import { useAssets } from "@/contexts/AssetViewerContext";
-import { AsteriskSquare, Box, Columns, Search } from "lucide-react";
-import { useState } from "react";
 import { DataTableFacetedFilter } from "./DataTableFacetedFilter";
 
 interface DataTableViewOptionsProps<TData> {
@@ -91,14 +68,7 @@ interface DataTableToolbarProps<TData> {
 export function DataTableToolbar<TData>({
   table,
 }: DataTableToolbarProps<TData>) {
-  const { query, setQuery, assets, submitSearch, filters, setFilters } =
-    useAssets();
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Enter") {
-      submitSearch();
-    }
-  };
+  const { assets, filters, setFilters } = useAssets();
 
   const isFiltered =
     filters.sources.length > 0 ||
@@ -110,19 +80,6 @@ export function DataTableToolbar<TData>({
       <div className="w-full">
         <div>
           <div className="space-y-4 w-full">
-            <div className="flex items-center">
-              <div className="relative w-full">
-                <Search className="size-4 absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
-                <Input
-                  autoFocus
-                  placeholder="Search assets"
-                  value={query}
-                  onChange={(event) => setQuery(event.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className="h-10 w-full pl-10"
-                />
-              </div>
-            </div>
             <div className="flex items-center justify-between">
               <div className="flex space-x-2 items-center">
                 {assets?.count > 0 ? (


### PR DESCRIPTION
Some notes - I think this is a non-trivial change. I'm not sure if we want to be wrapping the nav bar in a bunch of context provider stuff to allow for search, and based on what @ianrtracey was saying, it sounds like we'll want this bar to do asset search on `/assets`, some sort of filtering on `/lineage`, etc. IMO means this should get rethought a little

One idea would be to get rid of the context provider and have a single component that switches based on the path (maybe a fixed set of paths, otherwise show nothing?) and returns the input bar with the correct search functionality, but not sure exactly how that'd look at the end of the day