### PR TITLE
ENG-1244: Cards for New Connections

### DIFF
--- a/frontend/src/components/connections/forms/bigquery-form.tsx
+++ b/frontend/src/components/connections/forms/bigquery-form.tsx
@@ -187,46 +187,44 @@ export default function BigqueryForm({
               </FormItem>
             )}
           />
-          <div className="space-y-2">
+          <FormField
+            control={form.control}
+            name="should_filter_schema"
+            render={({ field }) => (
+              <FormItem>
+                <SchemaFilterCard
+                  title="Filter schemas (advanced)"
+                  description={
+                    shouldFilterSchema
+                      ? "Include only the following schemas:"
+                      : "Including all schemas"
+                  }
+                >
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                </SchemaFilterCard>
+              </FormItem>
+            )}
+          />
+          {shouldFilterSchema && (
             <FormField
               control={form.control}
-              name="should_filter_schema"
+              name="include_schemas"
               render={({ field }) => (
                 <FormItem>
-                  <SchemaFilterCard
-                    title="Filter schemas (advanced)"
-                    description={
-                      shouldFilterSchema
-                        ? "Include only the following schemas:"
-                        : "Including all schemas"
-                    }
-                  >
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
+                  <NewConnectionCard title="Add a line for each schema">
+                    <Textarea
+                      className="h-[150px]"
+                      placeholder={"Eg.\nschema1\nschema2"}
+                      {...field}
                     />
-                  </SchemaFilterCard>
+                  </NewConnectionCard>
                 </FormItem>
               )}
             />
-            {shouldFilterSchema && (
-              <FormField
-                control={form.control}
-                name="include_schemas"
-                render={({ field }) => (
-                  <FormItem>
-                    <NewConnectionCard title="Add a line for each schema">
-                      <Textarea
-                        className="h-[150px]"
-                        placeholder={"Eg.\nschema1\nschema2"}
-                        {...field}
-                      />
-                    </NewConnectionCard>
-                  </FormItem>
-                )}
-              />
-            )}
-          </div>
+          )}
           <div className="flex justify-end pb-4">
             {tested &&
               (connectionCheck ? (

--- a/frontend/src/components/connections/forms/bigquery-form.tsx
+++ b/frontend/src/components/connections/forms/bigquery-form.tsx
@@ -115,8 +115,6 @@ export default function BigqueryForm({
 
   const shouldFilterSchema = form.watch("should_filter_schema");
 
-  type ConnectionCardVariant = "default" | "sideBySideWithDescription";
-
   type ConnectionCardDefaultProps = {
     variant: "default";
     title: string;

--- a/frontend/src/components/connections/forms/bigquery-form.tsx
+++ b/frontend/src/components/connections/forms/bigquery-form.tsx
@@ -157,8 +157,8 @@ export default function BigqueryForm({
             )}
             <FormControl>{children}</FormControl>
           </CardContent>
-          <FormMessage />
         </Card>
+        <FormMessage />
       </FormItem>
     );
   }

--- a/frontend/src/components/connections/forms/bigquery-form.tsx
+++ b/frontend/src/components/connections/forms/bigquery-form.tsx
@@ -2,6 +2,12 @@
 import { createResource, updateResource } from "@/app/actions/actions";
 import { LoaderButton } from "@/components/ui/LoadingSpinner";
 import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+} from "@/components/ui/card";
+import {
   Form,
   FormControl,
   FormDescription,
@@ -17,7 +23,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
-import { z } from "zod";
+import { Schema, z } from "zod";
 
 const serviceAccountPlaceholder = `{
   "type": "service_account",
@@ -109,6 +115,44 @@ export default function BigqueryForm({
 
   const shouldFilterSchema = form.watch("should_filter_schema");
 
+  type NewConnectionCardProps = {
+    title: string;
+    description?: string;
+    children: React.ReactNode;
+  };
+
+  function NewConnectionCard({ title, children }: NewConnectionCardProps) {
+    return (
+      <Card className="rounded-md">
+        <CardHeader>
+          <FormLabel>{title}</FormLabel>
+        </CardHeader>
+        <CardContent>
+          <FormControl>{children}</FormControl>
+        </CardContent>
+        <FormMessage />
+      </Card>
+    );
+  }
+
+  function SchemaFilterCard({
+    title,
+    description,
+    children,
+  }: NewConnectionCardProps) {
+    return (
+      <Card className="rounded-md">
+        <CardHeader>
+          <FormLabel>{title}</FormLabel>
+        </CardHeader>
+        <CardContent className="gap-y-0.5 flex flex-row justify-between">
+          <FormDescription>{description}</FormDescription>
+          <FormControl>{children}</FormControl>
+        </CardContent>
+      </Card>
+    );
+  }
+
   return (
     <div className="w-full max-w-2xl">
       <Form {...form}>
@@ -121,28 +165,25 @@ export default function BigqueryForm({
             name="name"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Connection name</FormLabel>
-                <FormControl>
+                <NewConnectionCard title="Connection name">
                   <Input placeholder="my awesome connection" {...field} />
-                </FormControl>
-                <FormMessage />
+                </NewConnectionCard>
               </FormItem>
             )}
           />
+
           <FormField
             control={form.control}
             name="service_account"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Service account</FormLabel>
-                <FormControl>
+                <NewConnectionCard title="Service account">
                   <Textarea
                     className="h-[250px]"
                     placeholder={serviceAccountPlaceholder}
                     {...field}
                   />
-                </FormControl>
-                <FormMessage />
+                </NewConnectionCard>
               </FormItem>
             )}
           />
@@ -151,21 +192,20 @@ export default function BigqueryForm({
               control={form.control}
               name="should_filter_schema"
               render={({ field }) => (
-                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
-                  <div className="space-y-0.5">
-                    <FormLabel>Filter schemas (advanced)</FormLabel>
-                    <FormDescription>
-                      {shouldFilterSchema
+                <FormItem>
+                  <SchemaFilterCard
+                    title="Filter schemas (advanced)"
+                    description={
+                      shouldFilterSchema
                         ? "Include only the following schemas:"
-                        : "Including all schemas"}
-                    </FormDescription>
-                  </div>
-                  <FormControl>
+                        : "Including all schemas"
+                    }
+                  >
                     <Switch
                       checked={field.value}
                       onCheckedChange={field.onChange}
                     />
-                  </FormControl>
+                  </SchemaFilterCard>
                 </FormItem>
               )}
             />
@@ -174,24 +214,20 @@ export default function BigqueryForm({
                 control={form.control}
                 name="include_schemas"
                 render={({ field }) => (
-                  <FormItem className="bg-muted p-4">
-                    <div className="text-xs text-muted-foreground font-medium">
-                      Add a line for each schema
-                    </div>
-                    <FormControl>
+                  <FormItem>
+                    <NewConnectionCard title="Add a line for each schema">
                       <Textarea
                         className="h-[150px]"
                         placeholder={"Eg.\nschema1\nschema2"}
                         {...field}
                       />
-                    </FormControl>
-                    <FormMessage />
+                    </NewConnectionCard>
                   </FormItem>
                 )}
               />
             )}
           </div>
-          <div className="flex justify-end">
+          <div className="flex justify-end pb-4">
             {tested &&
               (connectionCheck ? (
                 <div className="text-green-500 mt-2 mr-2">

--- a/frontend/src/components/connections/forms/bigquery-form.tsx
+++ b/frontend/src/components/connections/forms/bigquery-form.tsx
@@ -24,7 +24,7 @@ import { useRouter } from "next/navigation";
 import { useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
-import { Schema, z } from "zod";
+import { z } from "zod";
 
 const serviceAccountPlaceholder = `{
   "type": "service_account",

--- a/frontend/src/components/connections/forms/bigquery-form.tsx
+++ b/frontend/src/components/connections/forms/bigquery-form.tsx
@@ -21,6 +21,7 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
+import { useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { Schema, z } from "zod";
@@ -50,6 +51,54 @@ const FormSchema = z.object({
   should_filter_schema: z.boolean(),
   include_schemas: z.string().optional(),
 });
+
+type ConnectionCardDefaultProps = {
+  variant: "default";
+  title: string;
+  description?: never;
+  children: React.ReactNode;
+};
+
+type ConnectionCardSideBySideWithDescriptionProps = {
+  variant: "sideBySideWithDescription";
+  title: string;
+  description: string;
+  children: React.ReactNode;
+};
+
+type NewConnectionCardProps =
+  | ConnectionCardDefaultProps
+  | ConnectionCardSideBySideWithDescriptionProps;
+
+function NewConnectionCard({
+  variant,
+  description,
+  title,
+  children,
+}: NewConnectionCardProps) {
+  return (
+    <FormItem>
+      <Card className="rounded-md">
+        <CardHeader>
+          <FormLabel>{title}</FormLabel>
+        </CardHeader>
+        <CardContent
+          className={
+            variant === "sideBySideWithDescription"
+              ? "gap-y-0.5 flex flex-row justify-between"
+              : ""
+          }
+        >
+          {variant === "sideBySideWithDescription" && (
+            <FormDescription>{description}</FormDescription>
+          )}
+          <FormControl>{children}</FormControl>
+        </CardContent>
+      </Card>
+      <FormMessage />
+    </FormItem>
+  );
+}
 
 export default function BigqueryForm({
   resource,
@@ -114,54 +163,6 @@ export default function BigqueryForm({
   }
 
   const shouldFilterSchema = form.watch("should_filter_schema");
-
-  type ConnectionCardDefaultProps = {
-    variant: "default";
-    title: string;
-    description?: never;
-    children: React.ReactNode;
-  };
-
-  type ConnectionCardSideBySideWithDescriptionProps = {
-    variant: "sideBySideWithDescription";
-    title: string;
-    description: string;
-    children: React.ReactNode;
-  };
-
-  type NewConnectionCardProps =
-    | ConnectionCardDefaultProps
-    | ConnectionCardSideBySideWithDescriptionProps;
-
-  function NewConnectionCard({
-    variant,
-    description,
-    title,
-    children,
-  }: NewConnectionCardProps) {
-    return (
-      <FormItem>
-        <Card className="rounded-md">
-          <CardHeader>
-            <FormLabel>{title}</FormLabel>
-          </CardHeader>
-          <CardContent
-            className={
-              variant === "sideBySideWithDescription"
-                ? "gap-y-0.5 flex flex-row justify-between"
-                : ""
-            }
-          >
-            {variant === "sideBySideWithDescription" && (
-              <FormDescription>{description}</FormDescription>
-            )}
-            <FormControl>{children}</FormControl>
-          </CardContent>
-        </Card>
-        <FormMessage />
-      </FormItem>
-    );
-  }
 
   return (
     <div className="w-full max-w-2xl">

--- a/frontend/src/components/connections/forms/bigquery-form.tsx
+++ b/frontend/src/components/connections/forms/bigquery-form.tsx
@@ -1,12 +1,7 @@
 "use client";
 import { createResource, updateResource } from "@/app/actions/actions";
 import { LoaderButton } from "@/components/ui/LoadingSpinner";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import {
   Form,
   FormControl,
@@ -21,7 +16,6 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
-import { useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";

--- a/frontend/src/components/connections/forms/bigquery-form.tsx
+++ b/frontend/src/components/connections/forms/bigquery-form.tsx
@@ -115,41 +115,53 @@ export default function BigqueryForm({
 
   const shouldFilterSchema = form.watch("should_filter_schema");
 
-  type NewConnectionCardProps = {
+  type ConnectionCardVariant = "default" | "sideBySideWithDescription";
+
+  type ConnectionCardDefaultProps = {
+    variant: "default";
     title: string;
-    description?: string;
+    description?: never;
     children: React.ReactNode;
   };
 
-  function NewConnectionCard({ title, children }: NewConnectionCardProps) {
-    return (
-      <Card className="rounded-md">
-        <CardHeader>
-          <FormLabel>{title}</FormLabel>
-        </CardHeader>
-        <CardContent>
-          <FormControl>{children}</FormControl>
-        </CardContent>
-        <FormMessage />
-      </Card>
-    );
-  }
+  type ConnectionCardSideBySideWithDescriptionProps = {
+    variant: "sideBySideWithDescription";
+    title: string;
+    description: string;
+    children: React.ReactNode;
+  };
 
-  function SchemaFilterCard({
-    title,
+  type NewConnectionCardProps =
+    | ConnectionCardDefaultProps
+    | ConnectionCardSideBySideWithDescriptionProps;
+
+  function NewConnectionCard({
+    variant,
     description,
+    title,
     children,
   }: NewConnectionCardProps) {
     return (
-      <Card className="rounded-md">
-        <CardHeader>
-          <FormLabel>{title}</FormLabel>
-        </CardHeader>
-        <CardContent className="gap-y-0.5 flex flex-row justify-between">
-          <FormDescription>{description}</FormDescription>
-          <FormControl>{children}</FormControl>
-        </CardContent>
-      </Card>
+      <FormItem>
+        <Card className="rounded-md">
+          <CardHeader>
+            <FormLabel>{title}</FormLabel>
+          </CardHeader>
+          <CardContent
+            className={
+              variant === "sideBySideWithDescription"
+                ? "gap-y-0.5 flex flex-row justify-between"
+                : ""
+            }
+          >
+            {variant === "sideBySideWithDescription" && (
+              <FormDescription>{description}</FormDescription>
+            )}
+            <FormControl>{children}</FormControl>
+          </CardContent>
+          <FormMessage />
+        </Card>
+      </FormItem>
     );
   }
 
@@ -164,48 +176,42 @@ export default function BigqueryForm({
             control={form.control}
             name="name"
             render={({ field }) => (
-              <FormItem>
-                <NewConnectionCard title="Connection name">
-                  <Input placeholder="my awesome connection" {...field} />
-                </NewConnectionCard>
-              </FormItem>
+              <NewConnectionCard variant="default" title="Connection name">
+                <Input placeholder="my awesome connection" {...field} />
+              </NewConnectionCard>
             )}
           />
-
           <FormField
             control={form.control}
             name="service_account"
             render={({ field }) => (
-              <FormItem>
-                <NewConnectionCard title="Service account">
-                  <Textarea
-                    className="h-[250px]"
-                    placeholder={serviceAccountPlaceholder}
-                    {...field}
-                  />
-                </NewConnectionCard>
-              </FormItem>
+              <NewConnectionCard variant="default" title="Service account">
+                <Textarea
+                  className="h-[250px]"
+                  placeholder={serviceAccountPlaceholder}
+                  {...field}
+                />
+              </NewConnectionCard>
             )}
           />
           <FormField
             control={form.control}
             name="should_filter_schema"
             render={({ field }) => (
-              <FormItem>
-                <SchemaFilterCard
-                  title="Filter schemas (advanced)"
-                  description={
-                    shouldFilterSchema
-                      ? "Include only the following schemas:"
-                      : "Including all schemas"
-                  }
-                >
-                  <Switch
-                    checked={field.value}
-                    onCheckedChange={field.onChange}
-                  />
-                </SchemaFilterCard>
-              </FormItem>
+              <NewConnectionCard
+                variant="sideBySideWithDescription"
+                title="Filter schemas (advanced)"
+                description={
+                  shouldFilterSchema
+                    ? "Include only the following schemas:"
+                    : "Including all schemas"
+                }
+              >
+                <Switch
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                />
+              </NewConnectionCard>
             )}
           />
           {shouldFilterSchema && (
@@ -213,15 +219,16 @@ export default function BigqueryForm({
               control={form.control}
               name="include_schemas"
               render={({ field }) => (
-                <FormItem>
-                  <NewConnectionCard title="Add a line for each schema">
-                    <Textarea
-                      className="h-[150px]"
-                      placeholder={"Eg.\nschema1\nschema2"}
-                      {...field}
-                    />
-                  </NewConnectionCard>
-                </FormItem>
+                <NewConnectionCard
+                  variant="default"
+                  title="Add a line for each schema"
+                >
+                  <Textarea
+                    className="h-[150px]"
+                    placeholder={"Eg.\nschema1\nschema2"}
+                    {...field}
+                  />
+                </NewConnectionCard>
               )}
             />
           )}


### PR DESCRIPTION
## [Better to review without whitespace](https://github.com/turntable-so/turntable/pull/173/files?diff=unified&w=1)

Example: 
<img width="961" alt="Screen Shot 2024-11-07 at 12 28 48 PM" src="https://github.com/user-attachments/assets/5215ff24-6320-4b87-a458-56470c039548">

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `bigquery-form.tsx` to use `NewConnectionCard` for form fields, enhancing UI layout and consistency.
> 
>   - **UI Refactoring**:
>     - Introduced `NewConnectionCard` component in `bigquery-form.tsx` to encapsulate form items.
>     - Supports `default` and `sideBySideWithDescription` variants for flexible UI configurations.
>   - **Form Changes**:
>     - Refactored `BigqueryForm` to use `NewConnectionCard` for `name`, `service_account`, and `should_filter_schema` fields.
>     - Improved UI layout and consistency by using cards for form fields.
>   - **Misc**:
>     - No new functionality added; focuses on UI refactoring for maintainability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for f44786ab484280f85cd2e02692a16e8f34fe4abd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->