### PR TITLE
fix error not propagating on preview query error

### DIFF
--- a/backend/app/views/query_views.py
+++ b/backend/app/views/query_views.py
@@ -47,7 +47,13 @@ class QueryPreviewView(APIView):
 
     def post(self, request):
         input = self._preprocess(request)
-        result = execute_query.si(**input).apply_async().get()
+        try:
+            result = execute_query.si(**input).apply_async().get()
+        except Exception as e:
+            return Response(
+                {"error": str(e)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         return self._post_process(result)
 
 

--- a/frontend/src/app/editor/[id]/page.tsx
+++ b/frontend/src/app/editor/[id]/page.tsx
@@ -1,36 +1,28 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
-import { cn } from "@/lib/utils";
 import Editor, { DiffEditor } from "@monaco-editor/react";
 import type { AgGridReact } from "ag-grid-react";
 import { Check, Loader2, X } from "lucide-react";
+import type React from "react";
 import { Fragment, useEffect, useRef, useState } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import useResizeObserver from "use-resize-observer";
-import { executeQueryPreview, getBranches, infer } from "../../actions/actions";
-import {
-  FilesProvider,
-  type OpenedFile,
-  useFiles,
-} from "../../contexts/FilesContext";
+import { executeQueryPreview, infer } from "../../actions/actions";
+import { type OpenedFile, useFiles } from "../../contexts/FilesContext";
 import "@/components/ag-grid-custom-theme.css"; // Custom CSS Theme for Data Grid
 import BottomPanel from "@/components/editor/bottom-panel";
-import { CommandPanelProvider } from "@/components/editor/command-panel/command-panel-context";
 import EditorSidebar from "@/components/editor/editor-sidebar";
 import FileTabs from "@/components/editor/file-tabs";
 import { Textarea } from "@/components/ui/textarea";
-import type React from "react";
 import { useLayoutContext } from "../../contexts/LayoutContext";
-import { LineageProvider } from "../../contexts/LineageContext";
 import { usePathname } from "next/navigation";
 import EditorTopBar from "@/components/editor/editor-top-bar";
 
 const PromptBox = ({
   setPromptBoxOpen,
 }: { setPromptBoxOpen: (open: boolean) => void }) => {
-  const { activeFile, setActiveFile, updateFileContent, } = useFiles();
+  const { activeFile, setActiveFile, updateFileContent } = useFiles();
 
   const [prompt, setPrompt] = useState("");
   const [model, setModel] = useState<"PROMPT" | "CONFIRM">("PROMPT");
@@ -190,7 +182,8 @@ function EditorContent({
   setPromptBoxOpen,
   containerWidth,
 }: { setPromptBoxOpen: (open: boolean) => void; containerWidth: number }) {
-  const { activeFile, updateFileContent, saveFile, setActiveFile, isCloning } = useFiles();
+  const { activeFile, updateFileContent, saveFile, setActiveFile, isCloning } =
+    useFiles();
 
   // Define your custom theme
   const customTheme = {
@@ -378,29 +371,36 @@ function EditorPageContent() {
   const [filesearchQuery, setFilesearchQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [queryPreviewError, setQueryPreviewError] = useState(null);
-  const pathname = usePathname()
-  const { fetchFiles, fetchBranch, branchName, branchId, isCloned, cloneBranch } = useFiles()
+  const pathname = usePathname();
+  const {
+    fetchFiles,
+    fetchBranch,
+    branchName,
+    branchId,
+    isCloned,
+    cloneBranch,
+  } = useFiles();
 
-  console.log({ branchName })
+  console.log({ branchName });
 
   useEffect(() => {
     if (branchId && isCloned) {
-      fetchFiles()
+      fetchFiles();
     }
     if (branchId && !isCloned) {
-      cloneBranch(branchId)
+      cloneBranch(branchId);
     }
-  }, [branchId, isCloned])
+  }, [branchId, isCloned]);
 
   useEffect(() => {
-    if (pathname && pathname.includes('/editor/')) {
-      const id = pathname.split('/').slice(-1)[0]
-      console.log({ id })
+    if (pathname && pathname.includes("/editor/")) {
+      const id = pathname.split("/").slice(-1)[0];
+      console.log({ id });
       if (id && id.length > 0) {
-        fetchBranch(id)
+        fetchBranch(id);
       }
     }
-  }, [pathname])
+  }, [pathname]);
 
   useEffect(() => {
     if (treeRef.current) {
@@ -467,7 +467,6 @@ function EditorPageContent() {
     selectedIndex,
   ]);
 
-
   const runQueryPreview = async () => {
     setIsLoading(true);
     setQueryPreview(null);
@@ -478,12 +477,15 @@ function EditorPageContent() {
       typeof activeFile.content === "string"
     ) {
       const query = activeFile.content;
-      const preview = await executeQueryPreview(query);
-      console.log({ preview })
-      if (preview.error) {
-        setQueryPreviewError(preview.error);
-      } else {
-        setQueryPreview(preview);
+      try {
+        const preview = await executeQueryPreview(query);
+        if (preview.error) {
+          setQueryPreviewError(preview.error);
+        } else {
+          setQueryPreview(preview);
+        }
+      } catch (e) {
+        setQueryPreviewError("Error running query");
       }
     }
     setIsLoading(false);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5cc1c7bb-46d6-44fe-9013-49eeb7bd7f90)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix error handling for query execution in backend and frontend by catching exceptions and returning appropriate error messages.
> 
>   - **Backend**:
>     - In `query_views.py`, wrap `execute_query` call in `post()` method with a `try-except` block to catch exceptions and return a 400 error with the exception message.
>   - **Frontend**:
>     - In `page.tsx`, update `runQueryPreview` to catch exceptions and set `queryPreviewError` to "Error running query" if an exception occurs.
>     - Remove unused imports and fix formatting issues in `page.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for e87ddd7d2183e1c51e9282c1a8d3a4152bd3277b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->