### PR TITLE
remove resources from editor page

### DIFF
--- a/frontend/src/components/editor/editor-sidebar.tsx
+++ b/frontend/src/components/editor/editor-sidebar.tsx
@@ -139,22 +139,22 @@ export default function EditorSidebar() {
             </div>
           </div>
         </ResizablePanel>
-        <div className="px-2 pb-2">
-          <ResizableHandle className="h-10" withHandle />
-        </div>
-        <ResizablePanel defaultSize={25} minSize={25} maxSize={70}>
-          <div className="h-full w-full">
-            <div className="flex items-center space-x-2 px-2">
-              <div className="px-1 text-black text-sm font-medium">
-                Resources
-              </div>
-            </div>
-            <ActionBar
-              context="EDITOR"
-              onSelectChange={onActionBarSelectChange}
-            />
-          </div>
-        </ResizablePanel>
+        {/*<div className="px-2 pb-2">*/}
+        {/*  <ResizableHandle className="h-10" withHandle />*/}
+        {/*</div>*/}
+        {/*<ResizablePanel defaultSize={25} minSize={25} maxSize={70}>*/}
+        {/*  <div className="h-full w-full">*/}
+        {/*    <div className="flex items-center space-x-2 px-2">*/}
+        {/*      <div className="px-1 text-black text-sm font-medium">*/}
+        {/*        Resources*/}
+        {/*      </div>*/}
+        {/*    </div>*/}
+        {/*    <ActionBar*/}
+        {/*      context="EDITOR"*/}
+        {/*      onSelectChange={onActionBarSelectChange}*/}
+        {/*    />*/}
+        {/*  </div>*/}
+        {/*</ResizablePanel>*/}
       </ResizablePanelGroup>
     </div>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Comment out 'Resources' section in `EditorSidebar` component, removing unused UI elements.
> 
>   - **UI Changes**:
>     - Comment out the 'Resources' section in `EditorSidebar` component in `editor-sidebar.tsx`, removing the `ResizablePanel` and `ActionBar` related to resources.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for fa0a27d261d1217ebaf784028014ba121c410c44. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->