### PR TITLE
fix lineage refresh button and don't refresh on every tab change

### DIFF
--- a/frontend/src/app/editor/[id]/page.tsx
+++ b/frontend/src/app/editor/[id]/page.tsx
@@ -381,8 +381,6 @@ function EditorPageContent() {
     cloneBranch,
   } = useFiles();
 
-  console.log({ branchName });
-
   useEffect(() => {
     if (branchId && isCloned) {
       fetchFiles();
@@ -395,7 +393,6 @@ function EditorPageContent() {
   useEffect(() => {
     if (pathname && pathname.includes("/editor/")) {
       const id = pathname.split("/").slice(-1)[0];
-      console.log({ id });
       if (id && id.length > 0) {
         fetchBranch(id);
       }

--- a/frontend/src/components/editor/bottom-panel.tsx
+++ b/frontend/src/components/editor/bottom-panel.tsx
@@ -18,8 +18,7 @@ import {
   Table as TableIcon,
   Terminal as TerminalIcon,
 } from "lucide-react";
-import { useEffect } from "react";
-import { Fragment } from "react";
+import { Fragment, useEffect } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { Panel, PanelResizeHandle } from "react-resizable-panels";
 import useResizeObserver from "use-resize-observer";
@@ -27,7 +26,6 @@ import { LineageView } from "../lineage/LineageView";
 import { Button } from "../ui/button";
 import { Tabs, TabsList, TabsTrigger } from "../ui/tabs";
 import CommandPanel from "./command-panel";
-import { useParams } from "next/navigation";
 
 const SkeletonLoadingTable = () => {
   return (
@@ -98,7 +96,7 @@ export default function BottomPanel({
         fetchFileBasedLineage(activeFile.node.path, branchId);
       }
     }
-  }, [activeFile, activeTab, fetchFileBasedLineage, branchId]);
+  }, [activeFile, branchId]);
 
   const { ref: bottomPanelRef, height: bottomPanelHeight } =
     useResizeObserver();
@@ -153,7 +151,9 @@ export default function BottomPanel({
           {activeTab === "lineage" && (
             <Button
               size="sm"
-              onClick={() => fetchFileBasedLineage(activeFile?.node.path || "")}
+              onClick={() =>
+                fetchFileBasedLineage(activeFile?.node.path || "", branchId)
+              }
               disabled={lineageData[activeFile?.node.path || ""]?.isLoading}
               variant="outline"
             >


### PR DESCRIPTION
https://github.com/user-attachments/assets/747050f6-fe41-4d5a-9b67-ce1e911bf03b


> [!IMPORTANT]
> Fix lineage refresh button and prevent unnecessary refreshes when `activeFile` changes in `bottom-panel.tsx`.
> 
>   - **Behavior**:
>     - Fix lineage refresh button in `bottom-panel.tsx` by updating `onClick` handler to include `branchId`.
>     - Prevent lineage refresh when `activeFile` changes by modifying `useEffect` dependencies in `bottom-panel.tsx`.
>   - **Misc**:
>     - Remove console logs from `page.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for f823d4a707632eabd9ec938c08ab390d1e7ea0b6. It will automatically update as commits are pushed.</sup>