### PR TITLE
remove debug print statements

### DIFF
--- a/backend/app/consumers/dbt_command_consumer.py
+++ b/backend/app/consumers/dbt_command_consumer.py
@@ -37,16 +37,11 @@ class DBTCommandConsumer(WebsocketConsumer):
         action = data.get("action")
 
         if action == "start":
-            if self.started:
-                self.send(text_data="TASK_ALREADY_RUNNING")
-                return
             self.started = True
-            self.send(text_data="WORKFLOW_STARTED")
             my_thread = threading.Thread(target=lambda: self.run_workflow(data))
             my_thread.start()
 
         elif action == "cancel":
-            self.send(text_data="WORKFLOW_CANCEL_REQUESTED")
             if self.started:
                 self.terminate_event.set()
                 self.send(text_data="WORKFLOW_CANCELLED")

--- a/backend/app/consumers/dbt_command_consumer.py
+++ b/backend/app/consumers/dbt_command_consumer.py
@@ -40,10 +40,12 @@ class DBTCommandConsumer(WebsocketConsumer):
             if self.started:
                 return
             self.started = True
+            self.send(text_data="WORKFLOW_STARTED")
             my_thread = threading.Thread(target=lambda: self.run_workflow(data))
             my_thread.start()
 
         elif action == "cancel":
+            self.send(text_data="WORKFLOW_CANCEL_REQUESTED")
             if self.started:
                 self.terminate_event.set()
                 self.send(text_data="WORKFLOW_CANCELLED")

--- a/backend/app/consumers/dbt_command_consumer.py
+++ b/backend/app/consumers/dbt_command_consumer.py
@@ -37,6 +37,8 @@ class DBTCommandConsumer(WebsocketConsumer):
         action = data.get("action")
 
         if action == "start":
+            if self.started:
+                return
             self.started = True
             my_thread = threading.Thread(target=lambda: self.run_workflow(data))
             my_thread.start()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove debug print statements from `receive()` in `dbt_command_consumer.py`.
> 
>   - **Behavior**:
>     - Removes debug print statements `TASK_ALREADY_RUNNING`, `WORKFLOW_STARTED`, and `WORKFLOW_CANCEL_REQUESTED` from `receive()` in `dbt_command_consumer.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for c9aa25cbf2191c6890501a1d200a95b646d98fb3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->