### PR TITLE
fix: s3 signed url handling

### DIFF
--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -270,16 +270,12 @@ elif "AWS_S3_ENDPOINT_HOST" in os.environ and "AWS_S3_ENDPOINT_PORT" in os.envir
 else:
     AWS_S3_ENDPOINT_URL = None
 
+AWS_S3_PUBLIC_URL = os.getenv("AWS_S3_PUBLIC_URL") or AWS_S3_ENDPOINT_URL
+
 
 AWS_DEFAULT_ACL = None
 AWS_QUERYSTRING_AUTH = True
 AWS_QUERYSTRING_EXPIRE = 60
-
-AWS_S3_PUBLIC_URL = (
-    os.getenv("AWS_S3_PUBLIC_URL")
-    if os.getenv("AWS_S3_PUBLIC_URL")
-    else "http://localhost:9000"
-)
 AWS_S3_SIGNATURE_VERSION = "s3v4"
 
 if region := os.getenv("AWS_S3_REGION_NAME"):
@@ -309,10 +305,10 @@ if os.getenv("LOCAL_REDIS") == "true":
     redis_host = os.getenv("REDIS_HOST", "localhost")
     redis_port = int(os.getenv("REDIS_PORT", 6379))
     redis_url = f"redis://{redis_host}:{redis_port}/"
+elif "REDIS_URL" not in os.environ:
+    raise ValueError("REDIS_URL is required if LOCAL_REDIS is not set to true")
 else:
-    redis_url = f"{os.getenv('REDIS_URL')}/" # we add a / cause Render injects the url without a /
-    if not redis_url:
-        raise ValueError("REDIS_URL is required if LOCAL_REDIS is not set to true")
+    redis_url = f"{os.getenv('REDIS_URL')}/"  # we add a / cause Render injects the url without a /
 
 CHANNEL_LAYERS = {
     "default": {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `AWS_S3_PUBLIC_URL` defaulting and improves `REDIS_URL` error handling in `settings.py`.
> 
>   - **AWS S3 Configuration**:
>     - `AWS_S3_PUBLIC_URL` now defaults to `AWS_S3_ENDPOINT_URL` if `AWS_S3_PUBLIC_URL` is not set in `settings.py`.
>   - **Redis Configuration**:
>     - Raises `ValueError` if `REDIS_URL` is not set and `LOCAL_REDIS` is not `true` in `settings.py`.
>     - Removes redundant check for `redis_url` being empty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 7cfdd4cb40084e66fbd7a8730f04d5712f6a1a75. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->