### PR TITLE
Ian/eng 1262 close all tabs file contents still there

### DIFF
--- a/frontend/src/app/contexts/FilesContext.tsx
+++ b/frontend/src/app/contexts/FilesContext.tsx
@@ -96,6 +96,18 @@ type FilesContextType = {
 
 const FilesContext = createContext<FilesContextType | undefined>(undefined);
 
+
+const defaultFileTab = {
+  node: {
+    name: "New tab",
+    path: `Untitled-${crypto.randomUUID()}`,
+    type: "file",
+  },
+  content: "",
+  isDirty: false,
+  view: "new",
+}
+
 type Changes = Array<{
   path: string;
   before: string;
@@ -115,16 +127,7 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
   const [openedFiles, setOpenedFiles] = useLocalStorage<OpenedFile[]>(
     LocalStorageKeys.fileTabs,
     [
-      {
-        node: {
-          name: "New tab",
-          path: `Untitled-${crypto.randomUUID()}`,
-          type: "file",
-        },
-        content: "",
-        isDirty: false,
-        view: "new",
-      },
+      defaultFileTab as OpenedFile
     ],
   );
   const [activeFile, setActiveFile] = useLocalStorage<OpenedFile | null>(
@@ -297,11 +300,20 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
         (f) => f.node.path !== file.node.path,
       );
       setOpenedFiles(newOpenedFiles);
-      if (newOpenedFiles.length > 0) {
-        setActiveFile(newOpenedFiles[0]);
+      if (newOpenedFiles.length === 0) {
+        setOpenedFiles([defaultFileTab as OpenedFile]);
+        setActiveFile(defaultFileTab as OpenedFile);
       }
+      else if (file.node.path === activeFile?.node.path) {
+        if (newOpenedFiles.length > 0) {
+          setActiveFile(newOpenedFiles[0]);
+        } else {
+          setActiveFile(null);
+        }
+      }
+
     },
-    [openedFiles],
+    [openedFiles, activeFile],
   );
 
   const createFileAndRefresh = async (path: string, fileContents: string) => {

--- a/frontend/src/app/contexts/FilesContext.tsx
+++ b/frontend/src/app/contexts/FilesContext.tsx
@@ -296,6 +296,7 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
 
   const closeFile = useCallback(
     (file: OpenedFile) => {
+      const fileIndex = openedFiles.findIndex(f => f.node.path === file.node.path);
       const newOpenedFiles = openedFiles.filter(
         (f) => f.node.path !== file.node.path,
       );
@@ -311,7 +312,6 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
           setActiveFile(null);
         }
       }
-
     },
     [openedFiles, activeFile],
   );

--- a/frontend/src/app/url.ts
+++ b/frontend/src/app/url.ts
@@ -1,5 +1,5 @@
 export default function getUrl() {
   return typeof window === "undefined"
-    ? "http://api:8000"
-    : "http://localhost:8000"
+    ? process.env.API_URL
+    : process.env.NEXT_PUBLIC_API_URL;
 }

--- a/frontend/src/app/url.ts
+++ b/frontend/src/app/url.ts
@@ -1,5 +1,5 @@
 export default function getUrl() {
   return typeof window === "undefined"
-    ? process.env.API_URL
-    : process.env.NEXT_PUBLIC_API_URL;
+    ? "http://api:8000"
+    : "http://localhost:8000"
 }


### PR DESCRIPTION
Adjusts tab logic to gracefully handle closures, re-focusing on close and empty states.

https://github.com/user-attachments/assets/ebdffef7-0ba3-4396-aad2-754d4cc7df67


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves tab management in `FilesContext.tsx` by introducing `defaultFileTab` and updating `closeFile` logic for better handling of empty and refocus states.
> 
>   - **Behavior**:
>     - Introduces `defaultFileTab` for handling empty tab states in `FilesContext.tsx`.
>     - Updates `closeFile` function to set `defaultFileTab` when all tabs are closed and refocuses on the first tab if the active tab is closed.
>   - **Refactoring**:
>     - Replaces inline default tab object with `defaultFileTab` constant in `FilesProvider`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for da151fdced73b36383f764a2024942f9e65f4142. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->