### PR TITLE
Adds deletion state to git integration 

### DIFF
--- a/backend/app/views/project_views.py
+++ b/backend/app/views/project_views.py
@@ -228,37 +228,30 @@ class ProjectViewSet(viewsets.ViewSet):
 
             # Get tracked modified files
             changed_files = []
+            deleted_files = []
             for item in repo.index.diff(None):
-                with open(os.path.join(repo.working_dir, item.a_path), "r") as file:
-                    after_content = file.read()
-                before_content = repo.git.show(f"HEAD:{item.a_path}")
-                changed_files.append(
-                    {
-                        "path": item.a_path,
-                        "before": before_content,
-                        "after": after_content,
-                    }
-                )
-
-            # Get staged files
-            staged_files = []
-            for item in repo.index.diff("HEAD"):
-                with open(os.path.join(repo.working_dir, item.a_path), "r") as file:
-                    after_content = file.read()
-                before_content = repo.git.show(f"HEAD:{item.a_path}")
-                staged_files.append(
-                    {
-                        "path": item.a_path,
-                        "before": before_content,
-                        "after": after_content,
-                    }
-                )
+                file_data = {
+                    "path": item.a_path,
+                    "before": "",
+                    "after": "",
+                }
+                # Handle deleted files
+                if item.deleted_file:
+                    file_data["before"] = repo.git.show(f"HEAD:{item.a_path}")
+                    file_data["after"] = ""
+                    deleted_files.append(file_data)
+                # Handle renamed files
+                else:
+                    file_data["before"] = repo.git.show(f"HEAD:{item.a_path}")
+                    with open(os.path.join(repo.working_dir, item.a_path), "r") as file:
+                        file_data["after"] = file.read()
+                        changed_files.append(file_data)
 
             return Response(
                 {
                     "untracked": untracked_files,
                     "modified": changed_files,
-                    "staged": staged_files,
+                    "deleted": deleted_files,
                 }
             )
 

--- a/frontend/src/app/actions/actions.ts
+++ b/frontend/src/app/actions/actions.ts
@@ -637,7 +637,7 @@ export type ProjectChanges = {
     before: string;
     after: string;
   }>;
-  staged: Array<{
+  deleted: Array<{
     path: string;
     before: string;
     after: string;

--- a/frontend/src/app/contexts/FilesContext.tsx
+++ b/frontend/src/app/contexts/FilesContext.tsx
@@ -129,7 +129,7 @@ type Changes = Array<{
   path: string;
   before: string;
   after: string;
-  type: "untracked" | "modified" | "staged";
+  type: "untracked" | "modified" | "deleted";
 }>;
 
 export const FilesProvider: React.FC<{ children: ReactNode }> = ({
@@ -211,9 +211,9 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
         })),
       )
       .concat(
-        result.staged.map((change) => ({
+        result.deleted.map((change) => ({
           ...change,
-          type: "staged",
+          type: "deleted",
         })),
       );
     setChanges(flattenedChanges as Changes);
@@ -373,10 +373,10 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
         prev.map((f) =>
           f.node.path === path
             ? {
-                ...f,
-                content,
-                node: { ...f.node, type: newNodeType },
-              }
+              ...f,
+              content,
+              node: { ...f.node, type: newNodeType },
+            }
             : f,
         ),
       );
@@ -453,7 +453,7 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
       }));
       return;
     }
-    
+
     const formattedProblems = data.errors.map((error: any) => ({
       message: error.msg,
     }));

--- a/frontend/src/components/editor/branch-review-dialog.tsx
+++ b/frontend/src/components/editor/branch-review-dialog.tsx
@@ -186,9 +186,9 @@ export default function BranchReviewDialog({
                             M
                           </Badge>
                         )}
-                        {change.type === "staged" && (
-                          <Badge variant="outline" className="text-yellow-500">
-                            S
+                        {change.type === "deleted" && (
+                          <Badge variant="outline" className="text-red-500">
+                            D
                           </Badge>
                         )}
                       </div>


### PR DESCRIPTION
Previously we weren't handling renamed or deleted files in our git integration

![Screenshot 2024-11-11 at 6 09 37 PM](https://github.com/user-attachments/assets/914a2ad4-a59a-40f3-83de-53403a580f03)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds handling for deleted and renamed files in git integration, updating both backend logic and frontend UI.
> 
>   - **Backend**:
>     - `project_views.py`: Adds handling for deleted files in `changes()` by introducing `deleted_files` list and updating response structure.
>   - **Frontend**:
>     - `actions.ts`: Changes `staged` to `deleted` in `ProjectChanges` type.
>     - `FilesContext.tsx`: Updates `Changes` type to include `deleted` and modifies `fetchChanges()` to handle deleted files.
>     - `branch-review-dialog.tsx`: Updates UI to display deleted files with a red badge labeled 'D'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 57b5ac84b30155d2cb7f94a0a9c104102c44ec75. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->