### PR TITLE
Fixes asset serializer for grid view

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -152,8 +152,6 @@ class ColumnSerializer(serializers.ModelSerializer):
 
 # minified asset serializers for listing in the asset tree
 class AssetIndexSerializer(serializers.ModelSerializer):
-    column_count = serializers.IntegerField(read_only=True)
-    unused_columns_count = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = Asset
@@ -163,8 +161,6 @@ class AssetIndexSerializer(serializers.ModelSerializer):
             "unique_name",
             "type",
             "resource_id",
-            "column_count",
-            "unused_columns_count",
         ]
 
 
@@ -177,6 +173,9 @@ class AssetSerializer(serializers.ModelSerializer):
     resource_id = serializers.PrimaryKeyRelatedField(
         source="resource.id", read_only=True
     )
+
+    column_count = serializers.IntegerField(read_only=True)
+    unused_columns_count = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = Asset
@@ -202,6 +201,8 @@ class AssetSerializer(serializers.ModelSerializer):
             "resource_has_dbt",
             "resource_name",
             "resource_id",
+            "column_count",
+            "unused_columns_count",
         ]
 
     def get_dataset(self, obj):

--- a/backend/app/views/asset_views.py
+++ b/backend/app/views/asset_views.py
@@ -146,9 +146,7 @@ class AssetViewSet(viewsets.ModelViewSet):
         # Paginate the filtered assets
         page = self.paginate_queryset(filtered_assets)
         if page is not None:
-            serializer = AssetIndexSerializer(
-                page, many=True, context={"request": request}
-            )
+            serializer = AssetSerializer(page, many=True, context={"request": request})
             response = self.get_paginated_response(serializer.data)
             response.data["filters"] = {
                 "types": list(types) if len(types) > 0 else [],
@@ -158,7 +156,7 @@ class AssetViewSet(viewsets.ModelViewSet):
             response.data["resources"] = resources_serializer.data
             return response
 
-        serializer = AssetIndexSerializer(
+        serializer = AssetSerializer(
             filtered_assets, many=True, context={"request": request}
         )
 

--- a/frontend/src/contexts/AssetViewerContext.tsx
+++ b/frontend/src/contexts/AssetViewerContext.tsx
@@ -1,4 +1,4 @@
-import { getAssets, getColumns } from "@/app/actions/actions";
+import { getAssets } from "@/app/actions/actions";
 import type { SortingState } from "@tanstack/react-table";
 import type React from "react";
 import {
@@ -11,7 +11,6 @@ import {
   useEffect,
   useState,
 } from "react";
-import { current } from "tailwindcss/colors";
 
 interface AssetViewerContextType {
   assets: any;


### PR DESCRIPTION
![Screenshot 2024-11-14 at 4 58 58 PM](https://github.com/user-attachments/assets/070bf12a-37b2-4e50-9a99-3ada50174932)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix asset serialization by moving `column_count` and `unused_columns_count` to `AssetSerializer` and updating `AssetViewSet` accordingly.
> 
>   - **Serializers**:
>     - Remove `column_count` and `unused_columns_count` from `AssetIndexSerializer` in `serializers.py`.
>     - Add `column_count` and `unused_columns_count` to `AssetSerializer` in `serializers.py`.
>   - **Views**:
>     - Replace `AssetIndexSerializer` with `AssetSerializer` in `list()` method of `AssetViewSet` in `asset_views.py`.
>   - **Frontend**:
>     - Remove `getColumns` import from `AssetViewerContext.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 614b0574e2a93fb4ca2604fcd55d07ab039093b8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->