### PR TITLE
Justin/eng-1400-terminal-colors

### DIFF
--- a/backend/vinyl/lib/dbt.py
+++ b/backend/vinyl/lib/dbt.py
@@ -485,7 +485,7 @@ class DBTProject(object):
             command,
             cli_args,
             write_json,
-            use_colors=True,
+            dbt_cache,
             defer,
             defer_selection,
             use_colors=True,

--- a/backend/vinyl/lib/dbt.py
+++ b/backend/vinyl/lib/dbt.py
@@ -485,7 +485,7 @@ class DBTProject(object):
             command,
             cli_args,
             write_json,
-            dbt_cache,
+            use_colors=True,
             defer,
             defer_selection,
             use_colors=True,

--- a/backend/vinyl/lib/dbt.py
+++ b/backend/vinyl/lib/dbt.py
@@ -399,6 +399,7 @@ class DBTProject(object):
         dbt_cache: bool = False,
         defer: bool = False,
         defer_selection: bool = True,
+        colors: bool = False,
     ) -> tuple[str, str, bool]:
         if cli_args is None:
             cli_args = []
@@ -407,7 +408,8 @@ class DBTProject(object):
         if not write_json:
             full_command.append("--no-write-json")
 
-        full_command.append("--no-use-colors")
+        if not colors:
+            full_command.append("--no-use-colors")
 
         if not self.dbt1_5:
             full_command.append("--no-anonymous-usage-stats")
@@ -486,6 +488,7 @@ class DBTProject(object):
             dbt_cache,
             defer,
             defer_selection,
+            colors=True,
         )
         if self.dbt1_5 and not force_terminal and not self.multitenant:
             # self.install_dbt_if_necessary()

--- a/backend/vinyl/lib/dbt.py
+++ b/backend/vinyl/lib/dbt.py
@@ -399,7 +399,7 @@ class DBTProject(object):
         dbt_cache: bool = False,
         defer: bool = False,
         defer_selection: bool = True,
-        colors: bool = False,
+        use_colors: bool = False,
     ) -> tuple[str, str, bool]:
         if cli_args is None:
             cli_args = []
@@ -408,7 +408,7 @@ class DBTProject(object):
         if not write_json:
             full_command.append("--no-write-json")
 
-        if not colors:
+        if not use_colors:
             full_command.append("--no-use-colors")
 
         if not self.dbt1_5:
@@ -488,7 +488,7 @@ class DBTProject(object):
             dbt_cache,
             defer,
             defer_selection,
-            colors=True,
+            use_colors=True,
         )
         if self.dbt1_5 and not force_terminal and not self.multitenant:
             # self.install_dbt_if_necessary()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `use_colors` parameter to control terminal color usage in DBT commands in `dbt.py`.
> 
>   - **Behavior**:
>     - Add `use_colors` parameter to `get_dbt_command()` in `dbt.py` to control terminal color usage.
>     - Modify `stream_dbt_command()` in `dbt.py` to default `use_colors` to `True`.
>   - **Command Construction**:
>     - Append `--no-use-colors` to DBT command in `get_dbt_command()` if `use_colors` is `False`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for b27ff066bd098c5d4684fd127b24bc017f38a5da. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->