### PR TITLE
Adds Compile and Query Preview Shortcuts

### DIFF
--- a/frontend/src/app/contexts/FilesContext.tsx
+++ b/frontend/src/app/contexts/FilesContext.tsx
@@ -26,6 +26,7 @@ import {
   changeFilePath,
   formatDbtQuery,
   compileDbtQuery,
+  executeQueryPreview,
 } from "../actions/actions";
 import { validateDbtQuery } from "../actions/client-actions";
 import { getDownloadableFile } from "../actions/client-actions";
@@ -143,6 +144,17 @@ type FilesContextType = {
   closeFilesToRight: (file: OpenedFile) => void;
   closeAllOtherFiles: (file: OpenedFile) => void;
   closeAllFiles: () => void;
+  runQueryPreview: () => Promise<void>;
+  queryPreview: QueryPreview | null;
+  queryPreviewError: string | null;
+  isQueryPreviewLoading: boolean;
+  setIsQueryPreviewLoading: Dispatch<SetStateAction<boolean>>;
+};
+
+
+type QueryPreview = {
+  rows?: Object;
+  signed_url: string;
 };
 
 const FilesContext = createContext<FilesContextType | undefined>(undefined);
@@ -173,6 +185,9 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
   const [filesLoading, setFilesLoading] = useState(false);
   const [readOnly, setReadOnly] = useState<boolean | undefined>(undefined);
   const [isCloned, setIsCloned] = useState<boolean | undefined>(undefined);
+  const [queryPreview, setQueryPreview] = useState<QueryPreview | null>(null);
+  const [isQueryPreviewLoading, setIsQueryPreviewLoading] = useState(false);
+  const [queryPreviewError, setQueryPreviewError] = useState<string | null>(null);
   const [pullRequestUrl, setPullRequestUrl] = useState<string | undefined>(
     undefined,
   );
@@ -731,6 +746,26 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
     setActiveFile(null);
   }, []);
 
+  const runQueryPreview = async () => {
+    setIsQueryPreviewLoading(true);
+    setQueryPreview(null);
+    setQueryPreviewError(null);
+    if (activeFile?.content && typeof activeFile.content === "string") {
+      const dbtSql = activeFile.content;
+      try {
+        const preview = await executeQueryPreview({ dbtSql, branchId });
+        if (preview.error) {
+          setQueryPreviewError(preview.error);
+        } else {
+          setQueryPreview(preview);
+        }
+      } catch (e) {
+        setQueryPreviewError("Error running query");
+      }
+    }
+    setIsQueryPreviewLoading(false);
+  };
+
   return (
     <FilesContext.Provider
       value={{
@@ -786,6 +821,11 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
         closeFilesToRight,
         closeAllOtherFiles,
         closeAllFiles,
+        runQueryPreview,
+        queryPreview,
+        queryPreviewError,
+        isQueryPreviewLoading,
+        setIsQueryPreviewLoading,
       }}>
       {children}
     </FilesContext.Provider>

--- a/frontend/src/components/editor/bottom-panel.tsx
+++ b/frontend/src/components/editor/bottom-panel.tsx
@@ -24,6 +24,7 @@ import { Badge } from "../ui/badge";
 import CommandPanelActionBtn from "./command-panel/command-panel-action-btn";
 import { Editor } from "@monaco-editor/react";
 import PreviewPanel from "./preview-panel/preview-panel";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
 // Define your custom theme
 const customTheme = {
@@ -52,7 +53,7 @@ export default function BottomPanel({
   queryPreviewError: string | null;
 }) {
   const { fetchFileBasedLineage, lineageData } = useLineage();
-  const { activeFile, branchId, problems, compileActiveFile, compiledSql, isCompiling, compileError } = useFiles();
+  const { activeFile, branchId, problems, compileActiveFile, compiledSql, isCompiling, compileError, isQueryPreviewLoading } = useFiles();
   const [activeTab, setActiveTab] = useBottomPanelTabs({
     branchId: branchId || "",
   });
@@ -78,7 +79,11 @@ export default function BottomPanel({
         >
           <TabsList>
             <TabsTrigger value="results">
-              <TableIcon className="h-4 w-4 mr-2" />
+              {isQueryPreviewLoading ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <TableIcon className="h-4 w-4 mr-2" />
+              )}
               Preview
             </TabsTrigger>
             <TabsTrigger value="compile">
@@ -121,29 +126,48 @@ export default function BottomPanel({
         </Tabs>
         <div className="mr-2">
           {showPreviewQueryButton && (
-            <Button
-              size="sm"
-              onClick={runQueryPreview}
-              disabled={isQueryLoading}
-              variant="outline"
-            >
-              {isQueryLoading ? (
-                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-              ) : (
-                <Play className="h-4 w-4 mr-2" />
-              )}
-              Preview
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  onClick={runQueryPreview}
+                  disabled={isQueryLoading}
+                  variant="outline"
+                >
+                  {isQueryLoading ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : (
+                    <Play className="h-4 w-4 mr-2" />
+                  )}
+                  Preview
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Preview Query (⌘ + Enter)</p>
+              </TooltipContent>
+            </Tooltip>
           )}
           {activeTab === "compile" && (
-            <Button
-              size="sm"
-              onClick={compileActiveFile}
-              disabled={isCompiling}
-              variant="outline"
-            >
-              Compile
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  onClick={compileActiveFile}
+                  disabled={isCompiling}
+                  variant="outline"
+                >
+                  {isCompiling ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : (
+                    <Play className="h-4 w-4 mr-2" />
+                  )}
+                  Compile
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Compile (⌘ + Shift + Enter)</p>
+              </TooltipContent>
+            </Tooltip>
           )}
           {activeTab === "lineage" && (
             <Button

--- a/frontend/src/components/editor/command-panel/command-panel-action-btn.tsx
+++ b/frontend/src/components/editor/command-panel/command-panel-action-btn.tsx
@@ -2,6 +2,7 @@ import {
   CircleSlash,
   CornerDownLeft,
   Loader2,
+  Play,
   Command as PlayIcon,
 } from "lucide-react";
 import { useEffect } from "react";
@@ -14,9 +15,9 @@ export default function CommandPanelActionBtn() {
 
   const componentMap = {
     idling: (
-      <div className="flex flex-row gap-0.5 items-center mr-2 text-base">
-        <PlayIcon className="h-4 w-4 mr-0.5" />
-        <CornerDownLeft className="h-4 w-4 mr-2" /> Run
+      <div className="flex flex-row gap-0.5 items-center">
+        <Play className="h-4 w-4 mr-2" />
+        <div className="text-xs">Run</div>
       </div>
     ),
     running: (
@@ -35,21 +36,6 @@ export default function CommandPanelActionBtn() {
 
   const isDisabled = commandPanelState === "cancelling";
 
-  const handleCommandEnterShortcut = () => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-        event.preventDefault();
-        runCommand();
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  };
-  useEffect(handleCommandEnterShortcut, [inputValue]);
 
   return (
     <Button


### PR DESCRIPTION
Query Preview - cmd + enter
Compile - cmd + shift + enter

https://github.com/user-attachments/assets/f4230cff-df37-47bd-acad-ac6cac2a9c73

![Screenshot 2024-11-14 at 6 15 27 PM](https://github.com/user-attachments/assets/c117eaf5-cc4c-4157-b6bf-d723e612101f)
![Screenshot 2024-11-14 at 6 08 33 PM](https://github.com/user-attachments/assets/8ec03768-817c-4310-a473-3388f0eaf823)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds keyboard shortcuts for query preview and compile actions, updates UI components, and enhances `FilesContext` for query preview support.
> 
>   - **Shortcuts**:
>     - Adds `cmd + enter` for query preview and `cmd + shift + enter` for compile in `page.tsx`.
>   - **UI Changes**:
>     - Updates `BottomPanel` to show loading indicators and tooltips for new shortcuts.
>     - Adds `Loader2` icon for loading states in `bottom-panel.tsx` and `command-panel-action-btn.tsx`.
>   - **Context Updates**:
>     - Adds `runQueryPreview`, `queryPreview`, `queryPreviewError`, and `isQueryPreviewLoading` to `FilesContext` in `FilesContext.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for f3cf6e844d49ed92b9b3f9c564a038c8d978364a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->