### PR TITLE
copy options in editor sidebar

### DIFF
--- a/backend/tests/views/test_project_views.py
+++ b/backend/tests/views/test_project_views.py
@@ -167,6 +167,20 @@ class TestProjectViews:
         assert response.status_code == 200
         assert 'select * from "mydb"' in response.json()
 
+    def test_duplicate_file(self, client, project):
+        response = client.post(
+            f"/project/{project.id}/files/duplicate/",
+            {"filepath": safe_encode("models/marts/customer360/customers.sql")},
+        )
+        assert response.status_code == 200
+
+    def test_duplicate_folder(self, client, project):
+        response = client.post(
+            f"/project/{project.id}/files/duplicate/",
+            {"filepath": safe_encode("models/marts/customer360")},
+        )
+        assert response.status_code == 200
+
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("local_postgres")

--- a/frontend/src/app/actions/actions.ts
+++ b/frontend/src/app/actions/actions.ts
@@ -620,6 +620,23 @@ export async function deleteFile(branchId: string, filePath: string) {
   return response.ok;
 }
 
+export async function duplicateFileOrFolder({
+  branchId,
+  filePath,
+}: {
+  branchId: string;
+  filePath: string;
+}) {
+  const response = await fetcher(`/project/${branchId}/files/duplicate/`, {
+    cookies,
+    method: "POST",
+    body: {
+      filepath: filePath,
+    },
+  });
+  return response.ok;
+}
+
 export async function infer({
   instructions,
   content,
@@ -767,9 +784,12 @@ export async function formatDbtQuery(payload: { query: string }) {
   return response.json();
 }
 
-export async function compileDbtQuery(project_id: string, payload: {
-  filepath: string;
-}) {
+export async function compileDbtQuery(
+  project_id: string,
+  payload: {
+    filepath: string;
+  },
+) {
   const response = await fetcher(`/project/${project_id}/compile/`, {
     cookies,
     method: "POST",

--- a/frontend/src/app/contexts/FilesContext.tsx
+++ b/frontend/src/app/contexts/FilesContext.tsx
@@ -27,9 +27,11 @@ import {
   formatDbtQuery,
   compileDbtQuery,
   executeQueryPreview,
+  duplicateFileOrFolder,
 } from "../actions/actions";
 import { validateDbtQuery } from "../actions/client-actions";
 import { getDownloadableFile } from "../actions/client-actions";
+import { toast } from "sonner";
 
 export const MAX_RECENT_COMMANDS = 5;
 
@@ -102,6 +104,7 @@ type FilesContextType = {
     isDirectory: boolean,
   ) => void;
   deleteFileAndRefresh: (path: string) => void;
+  duplicateFileOrFolderAndRefresh: (filePath: string) => void;
   createNewFileTab: () => void;
   changes: ProjectChanges | null;
   fetchChanges: (branchId: string) => void;
@@ -151,7 +154,6 @@ type FilesContextType = {
   setIsQueryPreviewLoading: Dispatch<SetStateAction<boolean>>;
 };
 
-
 type QueryPreview = {
   rows?: Object;
   signed_url: string;
@@ -187,7 +189,9 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
   const [isCloned, setIsCloned] = useState<boolean | undefined>(undefined);
   const [queryPreview, setQueryPreview] = useState<QueryPreview | null>(null);
   const [isQueryPreviewLoading, setIsQueryPreviewLoading] = useState(false);
-  const [queryPreviewError, setQueryPreviewError] = useState<string | null>(null);
+  const [queryPreviewError, setQueryPreviewError] = useState<string | null>(
+    null,
+  );
   const [pullRequestUrl, setPullRequestUrl] = useState<string | undefined>(
     undefined,
   );
@@ -499,6 +503,17 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
     await fetchFiles();
   };
 
+  const duplicateFileOrFolderAndRefresh = async (filePath: string) => {
+    const success = await duplicateFileOrFolder({
+      branchId,
+      filePath,
+    });
+    if (!success) {
+      toast.error("Failed to duplicate file");
+    }
+    await fetchFiles();
+  };
+
   const updateLoaderContent = useCallback(
     ({
       path,
@@ -783,6 +798,7 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
         searchFileIndex,
         createFileAndRefresh,
         deleteFileAndRefresh,
+        duplicateFileOrFolderAndRefresh,
         createNewFileTab,
         changes,
         fetchChanges,
@@ -828,7 +844,8 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
         queryPreviewError,
         isQueryPreviewLoading,
         setIsQueryPreviewLoading,
-      }}>
+      }}
+    >
       {children}
     </FilesContext.Provider>
   );

--- a/frontend/src/components/editor/file-tree-node.tsx
+++ b/frontend/src/components/editor/file-tree-node.tsx
@@ -1,3 +1,4 @@
+import { duplicateFileOrFolder } from "@/app/actions/actions";
 import { type OpenedFile, useFiles } from "@/app/contexts/FilesContext";
 import {
   ContextMenu,
@@ -22,6 +23,7 @@ import {
 } from "lucide-react";
 import { useState, useRef } from "react";
 import { useCopyToClipboard } from "usehooks-ts";
+import { toast } from "sonner";
 
 const DbtLogo = () => (
   <svg
@@ -46,10 +48,12 @@ export default function Node({
   dragHandle,
 }: { node: any; style: any; dragHandle: any }) {
   const {
+    branchId,
     activeFile,
     openFile,
     createFileAndRefresh,
     deleteFileAndRefresh,
+    duplicateFileOrFolderAndRefresh,
     closeFile,
     renameFile,
     createDirectoryAndRefresh,
@@ -148,6 +152,7 @@ export default function Node({
 
   const handleDuplicate = async (e: React.MouseEvent) => {
     e.stopPropagation();
+    await duplicateFileOrFolderAndRefresh(node.data.path);
   };
 
   const handleCopyName = async (e: React.MouseEvent) => {

--- a/frontend/src/components/editor/file-tree-node.tsx
+++ b/frontend/src/components/editor/file-tree-node.tsx
@@ -4,8 +4,10 @@ import {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuTrigger,
+  ContextMenuSeparator,
 } from "@/components/ui/context-menu";
 import {
+  Copy,
   Download,
   Ellipsis,
   File,
@@ -14,10 +16,12 @@ import {
   Folder,
   FolderOpen,
   FolderPlus,
+  Layers2,
   Pencil,
   Trash,
 } from "lucide-react";
 import { useState, useRef } from "react";
+import { useCopyToClipboard } from "usehooks-ts";
 
 const DbtLogo = () => (
   <svg
@@ -51,6 +55,7 @@ export default function Node({
     createDirectoryAndRefresh,
     downloadFile,
   } = useFiles();
+  const [copiedText, copy] = useCopyToClipboard();
   const [contextMenuOpen, setContextMenuOpen] = useState(false);
   const contextMenuRef = useRef<HTMLDivElement>(null);
 
@@ -141,6 +146,26 @@ export default function Node({
     }
   };
 
+  const handleDuplicate = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  const handleCopyName = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    copy(node.data.name);
+  };
+
+  const handleCopyPath = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    copy(node.data.path);
+  };
+
+  const handleCopyRef = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const filenameWithoutExtension = node.data.name.split(".")[0];
+    copy(`{{ ref('${filenameWithoutExtension}') }}`);
+  };
+
   return (
     <ContextMenu onOpenChange={setContextMenuOpen}>
       <ContextMenuTrigger ref={contextMenuRef} asChild>
@@ -223,12 +248,42 @@ export default function Node({
             Add Folder
           </div>
         </ContextMenuItem>
+        <ContextMenuItem onClick={handleDuplicate}>
+          <div className="flex items-center text-xs">
+            <Layers2 className="mr-2 h-3 w-3" />
+            Duplicate
+          </div>
+        </ContextMenuItem>
         <ContextMenuItem onClick={handleRename}>
           <div className="flex items-center text-xs">
             <Pencil className="mr-2 h-3 w-3" />
             Rename
           </div>
         </ContextMenuItem>
+
+        <ContextMenuSeparator />
+
+        <ContextMenuItem onClick={handleCopyName}>
+          <div className="flex items-center text-xs">
+            <Copy className="mr-2 h-3 w-3" />
+            Copy name
+          </div>
+        </ContextMenuItem>
+        <ContextMenuItem onClick={handleCopyPath}>
+          <div className="flex items-center text-xs">
+            <Copy className="mr-2 h-3 w-3" />
+            Copy relative path
+          </div>
+        </ContextMenuItem>
+        <ContextMenuItem onClick={handleCopyRef}>
+          <div className="flex items-center text-xs">
+            <Copy className="mr-2 h-3 w-3" />
+            Copy as ref
+          </div>
+        </ContextMenuItem>
+
+        <ContextMenuSeparator />
+
         <ContextMenuItem onClick={handleDownload}>
           <div className="flex items-center text-xs">
             <Download className="mr-2 h-3 w-3" />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add copy options for file name, path, and reference in the editor sidebar context menu.
> 
>   - **Behavior**:
>     - Adds `handleCopyName`, `handleCopyPath`, and `handleCopyRef` functions in `file-tree-node.tsx` to copy file name, path, and reference to clipboard.
>     - Integrates new copy options into the context menu with `ContextMenuItem` for "Copy name", "Copy relative path", and "Copy as ref".
>   - **UI Components**:
>     - Adds `ContextMenuSeparator` to visually separate new copy options from other menu items.
>     - Uses `Copy` icon from `lucide-react` for new copy options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 0745dd96599c60cfcf889380ce30c2417c7a850d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->