### PR TITLE
UI Tweaks (command bar, terminal)

### DIFF
--- a/frontend/src/components/editor/command-panel/command-log.tsx
+++ b/frontend/src/components/editor/command-panel/command-log.tsx
@@ -53,7 +53,7 @@ export default function CommandLog() {
 
   if (isExpanded) {
     return (
-      <div className="fixed inset-0 z-50 bg-white dark:bg-black overflow-hidden">
+      <div className="fixed inset-0 z-50 bg-black overflow-hidden">
         <Button
           variant="ghost"
           size="icon"

--- a/frontend/src/components/editor/command-panel/command-panel.tsx
+++ b/frontend/src/components/editor/command-panel/command-panel.tsx
@@ -19,10 +19,10 @@ export default function CommandPanel({
       <div className="flex flex-col flex-1 gap-2 min-h-0">
         {commandHistory.length > 0 ? (
           <div className="flex flex-1 min-h-0 gap-4">
-            <div className="w-1/3 flex flex-col border-2 rounded-md overflow-y-auto">
+            <div className="text-sm w-1/3 flex flex-col border-2 rounded-md overflow-y-auto">
               <CommandPanelList />
             </div>
-            <div className="w-2/3 flex flex-col rounded-md border-2 p-2 overflow-y-auto bg-black text-white hide-scrollbar">
+            <div className="text-sm w-2/3 flex flex-col rounded-md border-2 p-2 overflow-y-auto bg-black text-white hide-scrollbar">
               <CommandLog />
             </div>
           </div>


### PR DESCRIPTION
- expanded logs were unreadable (on a while background)
- command section had text that was too big (bigger than other text on the screen - ex: filetree). This frees up a bunch of space
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> UI improvements in `command-log.tsx` and `command-panel.tsx` for better readability and consistency.
> 
>   - **UI Improvements**:
>     - Change expanded log background color to black in `command-log.tsx` for better readability.
>     - Adjust text size to `text-sm` in `command-panel.tsx` for consistency with other UI elements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 8bd48844cf00b353c432ac30e76dd16accc3304f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->