### PR TITLE
hot fix - file saving shortcut not working

### DIFF
--- a/frontend/src/app/editor/[id]/page.tsx
+++ b/frontend/src/app/editor/[id]/page.tsx
@@ -364,7 +364,6 @@ function EditorContent({
         editor.addCommand(
           monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS,
           (e: any) => {
-            e.preventDefault();
             saveFile(activeFile?.node.path || "", editor.getValue());
           },
         );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix save file shortcut by removing `e.preventDefault()` in `EditorContent` in `page.tsx`.
> 
>   - **Behavior**:
>     - Removed `e.preventDefault()` from the save file shortcut command in `EditorContent` in `page.tsx`, allowing the default save behavior to proceed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for b5f6ceadada7cc561fc13517bb3596533fd42ddb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->