### PR TITLE
Fixes Query Preview Bug

### DIFF
--- a/frontend/src/app/contexts/FilesContext.tsx
+++ b/frontend/src/app/contexts/FilesContext.tsx
@@ -136,7 +136,7 @@ type FilesContextType = {
   createDirectoryAndRefresh: (path: string) => Promise<void>;
   filesLoading: boolean;
   downloadFile: (path: string) => Promise<void>;
-  compileActiveFile: () => Promise<void>;
+  compileActiveFile: (content?: string) => Promise<void>;
   compiledSql: string | null;
   isCompiling: boolean;
   compileError: string | null;
@@ -148,7 +148,7 @@ type FilesContextType = {
   closeFilesToRight: (file: OpenedFile) => void;
   closeAllOtherFiles: (file: OpenedFile) => void;
   closeAllFiles: () => void;
-  runQueryPreview: () => Promise<void>;
+  runQueryPreview: (content?: string) => Promise<void>;
   queryPreview: QueryPreview | null;
   queryPreviewError: string | null;
   isQueryPreviewLoading: boolean;
@@ -562,10 +562,10 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
         prev.map((f) =>
           f.node.path === path
             ? {
-                ...f,
-                content,
-                node: { ...f.node, type: newNodeType },
-              }
+              ...f,
+              content,
+              node: { ...f.node, type: newNodeType },
+            }
             : f,
         ),
       );
@@ -814,25 +814,24 @@ export const FilesProvider: React.FC<{ children: ReactNode }> = ({
     }
   }, [openedFiles, activeFile]);
 
-  const runQueryPreview = async () => {
+  const runQueryPreview = useCallback(async (content?: string) => {
     setIsQueryPreviewLoading(true);
     setQueryPreview(null);
     setQueryPreviewError(null);
-    if (activeFile?.content && typeof activeFile.content === "string") {
-      const dbtSql = activeFile.content;
-      try {
-        const preview = await executeQueryPreview({ dbtSql, branchId });
-        if (preview.error) {
-          setQueryPreviewError(preview.error);
-        } else {
-          setQueryPreview(preview);
-        }
-      } catch (e) {
-        setQueryPreviewError("Error running query");
+    if (
+      content ||
+      (activeFile?.content && typeof activeFile.content === "string")
+    ) {
+      const dbtSql = content || activeFile?.content;
+      const preview = await executeQueryPreview({ dbtSql, branchId });
+      if (preview.error) {
+        setQueryPreviewError(preview.error);
+      } else {
+        setQueryPreview(preview);
       }
     }
     setIsQueryPreviewLoading(false);
-  };
+  }, [activeFile]);
 
   return (
     <FilesContext.Provider

--- a/frontend/src/app/editor/[id]/page.tsx
+++ b/frontend/src/app/editor/[id]/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import type { AgGridReact } from "ag-grid-react";
 import { Check, Download, Loader2, X } from "lucide-react";
 import type React from "react";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import useResizeObserver from "use-resize-observer";
 import { infer } from "../../actions/actions";
@@ -26,7 +26,6 @@ const PromptBox = ({
   setPromptBoxOpen,
 }: { setPromptBoxOpen: (open: boolean) => void }) => {
   const { activeFile, setActiveFile, updateFileContent } = useFiles();
-
   const [prompt, setPrompt] = useState("");
   const [model, setModel] = useState<"PROMPT" | "CONFIRM">("PROMPT");
   const [isLoading, setIsLoading] = useState(false);
@@ -371,16 +370,12 @@ function EditorContent({
         // Prevent default behavior for cmd+s
         editor.addCommand(
           monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
-          (e: any) => {
-            runQueryPreview();
-          },
+          () => runQueryPreview(editor.getValue())
         );
 
         editor.addCommand(
           monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Enter,
-          (e: any) => {
-            compileActiveFile();
-          },
+          () => compileActiveFile(editor.getValue())
         );
       }}
     />

--- a/frontend/src/components/editor/bottom-panel.tsx
+++ b/frontend/src/components/editor/bottom-panel.tsx
@@ -149,7 +149,7 @@ export default function BottomPanel({
               <TooltipTrigger asChild>
                 <Button
                   size="sm"
-                  onClick={runQueryPreview}
+                  onClick={() => runQueryPreview()}
                   disabled={isQueryLoading}
                   variant="outline"
                 >


### PR DESCRIPTION
When running query preview with shortcut (ex: cmd+enter) it sends outdated file contents. This is because of the way monaco mounts. This PR allows us to avoid that problem by passing in the editor state directly
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes query preview bug by passing current editor state directly to `runQueryPreview` and `compileActiveFile`.
> 
>   - **Behavior**:
>     - Fixes outdated file content issue in query preview by passing current editor state directly.
>     - Updates `runQueryPreview` and `compileActiveFile` in `FilesContext.tsx` to accept optional `content` parameter.
>   - **Editor Commands**:
>     - Updates Monaco editor commands in `page.tsx` to pass current editor value to `runQueryPreview` and `compileActiveFile`.
>   - **UI**:
>     - Updates button click handlers in `bottom-panel.tsx` to use new `runQueryPreview` signature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 469178932c56b826816682bb80599405092d0f3e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->