### PR TITLE
Sami/eng 1424 add re run button for jobs

### DIFF
--- a/frontend/src/components/editor/command-panel/command-panel-context.tsx
+++ b/frontend/src/components/editor/command-panel/command-panel-context.tsx
@@ -47,6 +47,7 @@ interface CommandPanelContextType {
   setInputValue: Dispatch<SetStateAction<string>>;
   commandOptions: string[];
   setCommandOptions: Dispatch<SetStateAction<string[]>>;
+  runCommandCore: (command?: string) => void;
 }
 
 const defaultContextValue: CommandPanelContextType = {
@@ -62,6 +63,7 @@ const defaultContextValue: CommandPanelContextType = {
   setInputValue: () => {},
   commandOptions: [],
   setCommandOptions: () => {},
+  runCommandCore: () => {},
 };
 
 const CommandPanelContext =
@@ -203,7 +205,7 @@ export const CommandPanelProvider: FC<CommandPanelProviderProps> = ({
     },
   });
 
-  const _runCommandCore = (command?: string) => {
+  const runCommandCore = (command?: string) => {
     const payloadCommand = command ?? inputValue;
     startWebSocket({ command: payloadCommand });
     setCommandPanelState("running");
@@ -236,12 +238,12 @@ export const CommandPanelProvider: FC<CommandPanelProviderProps> = ({
       return;
     }
 
-    _runCommandCore();
+    runCommandCore();
   };
 
   const runCommandFromSearchBar = (command: string) => {
     setActiveTab("command");
-    _runCommandCore(command);
+    runCommandCore(command);
   };
 
   return (
@@ -259,6 +261,7 @@ export const CommandPanelProvider: FC<CommandPanelProviderProps> = ({
         setInputValue,
         commandOptions,
         setCommandOptions,
+        runCommandCore,
       }}
     >
       {children}

--- a/frontend/src/components/editor/command-panel/command-panel-list.tsx
+++ b/frontend/src/components/editor/command-panel/command-panel-list.tsx
@@ -1,4 +1,10 @@
-import { CircleCheck, CircleSlash, CircleX, LoaderCircle } from "lucide-react";
+import {
+  CircleCheck,
+  CircleSlash,
+  CircleX,
+  LoaderCircle,
+  Play,
+} from "lucide-react";
 import { useEffect } from "react";
 import { useCommandPanelContext } from "./command-panel-context";
 
@@ -9,6 +15,8 @@ export default function CommandPanelList() {
     setSelectedCommandIndex,
     commandPanelState,
     updateCommandById,
+    runCommand,
+    runCommandCore,
   } = useCommandPanelContext();
 
   useEffect(() => {
@@ -24,7 +32,7 @@ export default function CommandPanelList() {
       {commandHistory.map((item, index) => (
         <div
           key={item.id}
-          className={`flex justify-between ${
+          className={`group/item flex justify-between ${
             index === selectedCommandIndex ? "bg-gray-100 dark:bg-zinc-700" : ""
           } hover:bg-gray-100 dark:hover:bg-zinc-700 cursor-pointer p-2`}
           onClick={() => setSelectedCommandIndex(index)}
@@ -48,8 +56,23 @@ export default function CommandPanelList() {
             )}
             <p>dbt {item.command}</p>
           </div>
-          <div className="flex flex-row gap-2 items-center">
-            {item.duration && <p>{item.duration}</p>}
+          <div className="flex items-center">
+            {item.duration && (
+              <p className="group-hover/item:hidden">{item.duration}</p>
+            )}
+            <div className="hidden group-hover/item:block">
+              <button
+                type="button"
+                className="group/run flex items-center gap-1 rounded hover:bg-gray-200 dark:hover:bg-zinc-950 text-sm px-2"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  runCommandCore(item.command);
+                }}
+              >
+                <Play className="h-3 w-3" />
+                <span>Run</span>
+              </button>
+            </div>
           </div>
         </div>
       ))}

--- a/frontend/src/components/editor/command-panel/command-panel-list.tsx
+++ b/frontend/src/components/editor/command-panel/command-panel-list.tsx
@@ -1,3 +1,4 @@
+import React, { useEffect, useState } from "react";
 import {
   CircleCheck,
   CircleSlash,
@@ -5,7 +6,6 @@ import {
   LoaderCircle,
   Play,
 } from "lucide-react";
-import { useEffect } from "react";
 import { useCommandPanelContext } from "./command-panel-context";
 
 export default function CommandPanelList() {
@@ -15,9 +15,10 @@ export default function CommandPanelList() {
     setSelectedCommandIndex,
     commandPanelState,
     updateCommandById,
-    runCommand,
     runCommandCore,
   } = useCommandPanelContext();
+
+  const [isButtonHovered, setIsButtonHovered] = useState(false);
 
   useEffect(() => {
     commandHistory.forEach((command) => {
@@ -33,8 +34,12 @@ export default function CommandPanelList() {
         <div
           key={item.id}
           className={`group/item flex justify-between ${
-            index === selectedCommandIndex ? "bg-gray-100 dark:bg-zinc-700" : ""
-          } hover:bg-gray-100 dark:hover:bg-zinc-700 cursor-pointer p-2`}
+            index === selectedCommandIndex && !isButtonHovered
+              ? "bg-zinc-200 dark:bg-zinc-700"
+              : ""
+          } ${
+            !isButtonHovered ? "hover:bg-zinc-200 dark:hover:bg-zinc-700" : ""
+          } cursor-pointer p-2`}
           onClick={() => setSelectedCommandIndex(index)}
         >
           <div
@@ -63,7 +68,9 @@ export default function CommandPanelList() {
             <div className="hidden group-hover/item:block">
               <button
                 type="button"
-                className="group/run flex items-center gap-1 rounded hover:bg-gray-200 dark:hover:bg-zinc-950 text-sm px-2"
+                className="group/run flex items-center gap-1 rounded hover:bg-gray-200 dark:hover:bg-zinc-700 text-sm px-2"
+                onMouseEnter={() => setIsButtonHovered(true)}
+                onMouseLeave={() => setIsButtonHovered(false)}
                 onClick={(e) => {
                   e.stopPropagation();
                   runCommandCore(item.command);

--- a/frontend/src/components/editor/command-panel/command-panel-list.tsx
+++ b/frontend/src/components/editor/command-panel/command-panel-list.tsx
@@ -18,7 +18,9 @@ export default function CommandPanelList() {
     runCommandCore,
   } = useCommandPanelContext();
 
-  const [isButtonHovered, setIsButtonHovered] = useState(false);
+  const [hoveredButtonIndex, setHoveredButtonIndex] = useState<number | null>(
+    null,
+  );
 
   useEffect(() => {
     commandHistory.forEach((command) => {
@@ -34,11 +36,13 @@ export default function CommandPanelList() {
         <div
           key={item.id}
           className={`group/item flex justify-between ${
-            index === selectedCommandIndex && !isButtonHovered
+            index === selectedCommandIndex && hoveredButtonIndex !== index
               ? "bg-zinc-200 dark:bg-zinc-700"
               : ""
           } ${
-            !isButtonHovered ? "hover:bg-zinc-200 dark:hover:bg-zinc-700" : ""
+            hoveredButtonIndex !== index
+              ? "hover:bg-zinc-200 dark:hover:bg-zinc-700"
+              : ""
           } cursor-pointer p-2`}
           onClick={() => setSelectedCommandIndex(index)}
         >
@@ -69,8 +73,8 @@ export default function CommandPanelList() {
               <button
                 type="button"
                 className="group/run flex items-center gap-1 rounded hover:bg-gray-200 dark:hover:bg-zinc-700 text-sm px-2"
-                onMouseEnter={() => setIsButtonHovered(true)}
-                onMouseLeave={() => setIsButtonHovered(false)}
+                onMouseEnter={() => setHoveredButtonIndex(index)}
+                onMouseLeave={() => setHoveredButtonIndex(null)}
                 onClick={(e) => {
                   e.stopPropagation();
                   runCommandCore(item.command);

--- a/frontend/src/components/lineage/LineagePreview.tsx
+++ b/frontend/src/components/lineage/LineagePreview.tsx
@@ -1,6 +1,7 @@
 "use client";
+
 import { getLineage } from "@/app/actions/actions";
-import { LineageView } from "@/components/lineage/LineageView";
+import LineageView from "@/components/lineage/LineagePreview";
 import { Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
@@ -35,23 +36,21 @@ export default function LineagePreview({ nodeId }: { nodeId: string }) {
   return (
     <div>
       <ErrorBoundary FallbackComponent={() => <div>Something went wrong</div>}>
-        <>
-          {isLoading ? (
-            <div className="h-[400px] flex items-center justify-center text-gray-300">
-              <Loader2 className="h-6 w-6 animate-spin" />
-            </div>
-          ) : (
-            lineage &&
-            rootAsset && (
-              <LineageView
-                lineage={lineage}
-                rootAsset={rootAsset}
-                style={{ height: "600px" }}
-                page={"lineage"}
-              />
-            )
-          )}
-        </>
+        {isLoading ? (
+          <div className="h-[400px] flex items-center justify-center text-gray-300">
+            <Loader2 className="h-6 w-6 animate-spin" />
+          </div>
+        ) : (
+          lineage &&
+          rootAsset && (
+            <LineageView
+              lineage={lineage}
+              rootAsset={rootAsset}
+              style={{ height: "600px" }}
+              page={"lineage"}
+            />
+          )
+        )}
       </ErrorBoundary>
     </div>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a re-run button for command history items in the command panel and refactors related code.
> 
>   - **Command Panel**:
>     - Adds `runCommandCore` function to `command-panel-context.tsx` for executing commands.
>     - Exposes `runCommandCore` in `CommandPanelProvider` context.
>     - Refactors `_runCommandCore` to `runCommandCore`.
>   - **UI Enhancements**:
>     - Adds a re-run button with `Play` icon in `command-panel-list.tsx` for each command history item.
>     - Implements hover effect to show the re-run button.
>   - **Misc**:
>     - Fixes import of `LineageView` in `LineagePreview.tsx`.
>     - Removes unnecessary fragment in `LineagePreview.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 918bcb3ad140c3ad558542b672d5698e902d0ff7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->