### PR TITLE
cmd click lineage

### DIFF
--- a/frontend/src/components/lineage/ColumnLineage.tsx
+++ b/frontend/src/components/lineage/ColumnLineage.tsx
@@ -154,6 +154,9 @@ const ColumnLineageFlow = () => {
   }, [nodesInitialized, reactFlowInstance]);
 
   const handleCtrlClickOnNode = (node: any) => {
+    if (!files || !files[0]?.children || !branchId) {
+      return;
+    }
     const nodeNameParts = node.name.split(".");
     const targetFileName = nodeNameParts[nodeNameParts.length - 1];
 

--- a/frontend/src/components/lineage/ColumnLineage.tsx
+++ b/frontend/src/components/lineage/ColumnLineage.tsx
@@ -153,13 +153,6 @@ const ColumnLineageFlow = () => {
     });
   }, [nodesInitialized, reactFlowInstance]);
 
-  interface FileItem {
-    name: string;
-    type: "file" | "directory";
-    path: string;
-    children?: FileItem[];
-  }
-
   const handleCtrlClickOnNode = (node: any) => {
     const nodeNameParts = node.name.split(".");
     const targetFileName = nodeNameParts[nodeNameParts.length - 1];
@@ -168,7 +161,7 @@ const ColumnLineageFlow = () => {
       (child) => child.path === "models",
     );
 
-    const findFileByName = (items: FileItem[]): FileItem | null => {
+    const findFileByName = (items: any[]): any => {
       for (const item of items) {
         const itemBaseName = item.name.split(".")[0];
         if (item.type === "file" && itemBaseName === targetFileName) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `ColumnLineageFlow` to open files on Ctrl-clicking nodes and clean up imports in `ColumnLineage.tsx`.
> 
>   - **Behavior**:
>     - Add `handleCtrlClickOnNode` in `ColumnLineage.tsx` to open files on Ctrl-clicking nodes.
>     - Modify `onNodeClick` to handle Ctrl-click events, calling `handleCtrlClickOnNode`.
>   - **Imports**:
>     - Remove unused imports: `usePathname` and specific label components from `ColumnConnectionEdge`.
>     - Change `import React` to `import type React` for type-only import.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 4bc5af5adf9a251b1fb514e77d7676df81196fb9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->