### PR TITLE
fix run tab

### DIFF
--- a/frontend/src/app/jobs/page.tsx
+++ b/frontend/src/app/jobs/page.tsx
@@ -15,22 +15,18 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import dayjs from "dayjs";
 import { Loader2, Plus } from "lucide-react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
 type JobsPageProps = {
   searchParams: {
-    type?: "jobs" | "runs";
     page?: number;
     pageSize?: number;
   };
 };
 
 export default function JobsPage({ searchParams }: JobsPageProps) {
-  const type = searchParams.type || "jobs";
   const page = Number(searchParams.page || 1);
   const pageSize = Number(searchParams.pageSize || 5);
-  const pathname = usePathname();
 
   const paginationParams = {
     page,
@@ -117,10 +113,9 @@ export default function JobsPage({ searchParams }: JobsPageProps) {
       stopPolling();
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [pathname, type, page, pageSize]);
+  }, [page, pageSize]);
 
   const TabNames = { jobs: "Jobs", runs: "Runs" };
-  const selectedTab = type === "jobs" ? TabNames.jobs : TabNames.runs;
 
   const NewJobButton = () => (
     <Link href="/jobs/new">
@@ -143,34 +138,26 @@ export default function JobsPage({ searchParams }: JobsPageProps) {
 
   return (
     <FullWidthPageLayout title="Jobs" button={<NewJobButton />}>
-      <Tabs defaultValue={selectedTab}>
+      <Tabs defaultValue={TabNames.jobs}>
         <TabsList className="grid w-full grid-cols-2">
-          <TabsTrigger value={TabNames.jobs} asChild>
-            <Link href={"/jobs"}>{TabNames.jobs}</Link>
-          </TabsTrigger>
-          <TabsTrigger value={TabNames.runs} asChild>
-            <Link href={"/jobs?type=runs"}>{TabNames.runs}</Link>
-          </TabsTrigger>
+          <TabsTrigger value={TabNames.jobs}>Jobs</TabsTrigger>
+          <TabsTrigger value={TabNames.runs}>Runs</TabsTrigger>
         </TabsList>
         <TabsContent value={TabNames.jobs}>
-          {type === "jobs" ? (
-            <JobsList
-              jobs={jobsResult.results || []}
-              page={page}
-              pageSize={pageSize}
-              count={jobsResult.count}
-            />
-          ) : null}
+          <JobsList
+            jobs={jobsResult.results || []}
+            page={page}
+            pageSize={pageSize}
+            count={jobsResult.count}
+          />
         </TabsContent>
         <TabsContent value={TabNames.runs}>
-          {type === "runs" ? (
-            <RunsList
-              runs={runsResult.results || []}
-              page={page}
-              pageSize={pageSize}
-              count={runsResult.count}
-            />
-          ) : null}
+          <RunsList
+            runs={runsResult.results || []}
+            page={page}
+            pageSize={pageSize}
+            count={runsResult.count}
+          />
         </TabsContent>
       </Tabs>
     </FullWidthPageLayout>

--- a/frontend/src/components/jobs/jobs-list.tsx
+++ b/frontend/src/components/jobs/jobs-list.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import type { Job } from "@/app/actions/actions";
-import JobCard from "./job-card";
 import { Fragment } from "react";
+import JobCard from "./job-card";
 import JobRunPagination from "./job-run-pagination";
 
 type JobsListProps = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix run tab by removing `type` parameter and simplifying tab logic in `JobsPage`.
> 
>   - **Behavior**:
>     - Remove `type` parameter from `JobsPage` in `page.tsx`, simplifying tab logic.
>     - Default tab set to `Jobs` in `Tabs` component in `page.tsx`.
>     - Always render both `JobsList` and `RunsList` components in `TabsContent` in `page.tsx`.
>   - **Imports**:
>     - Reorder imports in `jobs-list.tsx` to place `JobCard` after `Fragment`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 0f484abb4de1bc165352ddec05663016cf031017. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->