### PR TITLE
Justin/eng-1457-add-celery-info-into-sentry

### DIFF
--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import dj_database_url
 import sentry_sdk
+from sentry_sdk.integrations.celery import CeleryIntegration
 
 SENTRY_DSN = os.getenv("SENTRY_DSN")
 
@@ -24,6 +25,7 @@ if SENTRY_DSN:
         dsn=SENTRY_DSN,
         traces_sample_rate=1.0,
         profiles_sample_rate=1.0,
+        integrations=[CeleryIntegration(monitor_beat_tasks=True)],
     )
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -86,7 +86,7 @@ dependencies = [
     "django-celery-results>=2.5.1",
     "django-celery-beat>=2.7.0",
     "croniter>=5.0.1",
-    "sentry-sdk[django]>=2.18.0",
+    "sentry-sdk[django,celery]>=2.18.0",
 ]
 
 [project.scripts]

--- a/backend/requirements-dev.lock
+++ b/backend/requirements-dev.lock
@@ -92,6 +92,7 @@ celery==5.4.0
     # via django-celery-results
     # via flower
     # via pytest-celery
+    # via sentry-sdk
 certifi==2024.8.30
     # via httpcore
     # via httpx

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -85,6 +85,7 @@ celery==5.4.0
     # via django-celery-beat
     # via django-celery-results
     # via flower
+    # via sentry-sdk
 certifi==2024.8.30
     # via httpcore
     # via httpx

--- a/backend/tests/views/test_orchestration_views.py
+++ b/backend/tests/views/test_orchestration_views.py
@@ -136,22 +136,3 @@ class TestOrchestrationViews:
 
         response = requests.get(url)
         assert response.status_code == 200
-
-    def test_cancel_orchestration(self, client, custom_celery, scheduled_workflow):
-        time.sleep(1)
-        response = client.post(f"/jobs/{scheduled_workflow.id}/start/")
-        assert response.status_code == 202
-        workflow = DBTOrchestrator.objects.get(id=response.data["id"])
-        task_id = workflow.await_next_id()
-        time.sleep(1)
-        print(task_id)
-        response = client.post(f"/runs/{task_id}/cancel/")
-        assert response.status_code == 200
-        assert response.data["message"] == "Task cancelled successfully"
-
-        # confirm task is cancelled
-        time.sleep(1)
-        response = client.get(f"/runs/{task_id}/")
-        assert response.status_code == 200
-        breakpoint()
-        assert response.data["status"] == "CANCELLED"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add Celery integration to Sentry for task monitoring and update dependencies accordingly.
> 
>   - **Sentry Integration**:
>     - Add `CeleryIntegration` to Sentry in `settings.py` with `monitor_beat_tasks=True`.
>   - **Dependencies**:
>     - Update `sentry-sdk` dependency in `pyproject.toml` to include `celery`.
>     - Reflect dependency update in `requirements-dev.lock` and `requirements.lock`.
>   - **Tests**:
>     - Remove `test_cancel_orchestration` function in `test_orchestration_views.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 2c9fd45be9f8df2682965a1e8775a0e70eebaaaa. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->