### PR TITLE
fix pyyaml patch

### DIFF
--- a/backend/vinyl/lib/utils/patch.py
+++ b/backend/vinyl/lib/utils/patch.py
@@ -70,21 +70,21 @@ def patch_json_with_orjson(func):
 def with_libyaml():
     """Temporarily patch yaml module to use libyaml implementations."""
     try:
-        from yaml import CDumper, CLoader, Dumper, Loader
+        import yaml
     except ImportError:
         yield
         return
 
-    original_loader = Loader
-    original_dumper = Dumper
+    original_loader = yaml.Loader
+    original_dumper = yaml.Dumper
 
     try:
-        Loader = CLoader
-        Dumper = CDumper
+        yaml.Loader = yaml.CLoader
+        yaml.Dumper = yaml.CDumper
         yield
     finally:
-        Loader = original_loader
-        Dumper = original_dumper
+        yaml.Loader = original_loader
+        yaml.Dumper = original_dumper
 
 
 def patch_yaml_with_libyaml(func):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes import method in `with_libyaml()` to correctly patch `yaml` with `CLoader` and `CDumper`.
> 
>   - **Behavior**:
>     - Fixes import method in `with_libyaml()` to import `yaml` module instead of individual components.
>     - Ensures `yaml.Loader` and `yaml.Dumper` are patched with `yaml.CLoader` and `yaml.CDumper` respectively.
>   - **Functions**:
>     - Modifies `with_libyaml()` in `patch.py` to handle `yaml` imports correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 3ce8fac9b64204f3435940e27234352c2ca64cf3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->