### PR TITLE
Sami/eng 1491 cancel load of lineage and problems tab when clicking on

### DIFF
--- a/backend/app/views/project_views.py
+++ b/backend/app/views/project_views.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import time
 from urllib.parse import unquote
 
 from django.db import transaction
@@ -527,6 +528,7 @@ class ProjectViewSet(viewsets.ViewSet):
 
     @action(detail=True, methods=["GET"])
     def lineage(self, request, pk=None):
+        time.sleep(4)
         workspace = request.user.current_workspace()
         dbt_details = workspace.get_dbt_dev_details()
 

--- a/backend/app/views/project_views.py
+++ b/backend/app/views/project_views.py
@@ -1,16 +1,13 @@
 import os
 import shutil
-import time
 from urllib.parse import unquote
 
 from django.db import transaction
-from django.db.models import Q
 from django.http import HttpResponse, JsonResponse
 from git import GitCommandError
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from sentry_sdk import capture_exception
 
 from api.serializers import LineageAssetSerializer, LineageSerializer, ProjectSerializer
 from app.core.lineage import get_lineage_helper
@@ -528,7 +525,6 @@ class ProjectViewSet(viewsets.ViewSet):
 
     @action(detail=True, methods=["GET"])
     def lineage(self, request, pk=None):
-        time.sleep(4)
         workspace = request.user.current_workspace()
         dbt_details = workspace.get_dbt_dev_details()
 

--- a/frontend/src/app/contexts/LineageView.tsx
+++ b/frontend/src/app/contexts/LineageView.tsx
@@ -1,14 +1,14 @@
 "use client";
 
+import { type Edge, ReactFlowProvider } from "@xyflow/react";
+import { AlertCircle } from "lucide-react";
+import { useParams, usePathname } from "next/navigation";
 import React, { useEffect, useRef, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { type Edge, ReactFlowProvider } from "@xyflow/react";
 import ColumnLineage from "../../components/lineage/ColumnLineage";
-import { AlertCircle } from "lucide-react";
-import { getLineage, getProjectBasedLineage } from "../actions/actions";
-import { useAppContext } from "../../contexts/AppContext";
 import { Alert, AlertDescription, AlertTitle } from "../../components/ui/alert";
-import { useParams, usePathname } from "next/navigation";
+import { useAppContext } from "../../contexts/AppContext";
+import { getLineage, getProjectBasedLineage } from "../actions/actions";
 import { useFiles } from "./FilesContext";
 
 export type WithMousePosition<T> = T & {
@@ -86,7 +86,7 @@ export const LineageViewContext = React.createContext<{
   lineage: null,
   isTableOnly: true,
   isFilterOpen: false,
-  toggleFilter: () => { },
+  toggleFilter: () => {},
   isLoading: true,
   isLoadingColumns: true,
   error: null,
@@ -105,20 +105,20 @@ export const LineageViewContext = React.createContext<{
     asset_only: true,
   },
   isLineageOptionsPanelOpen: false,
-  setIsLineageOptionsPanelOpen: () => { },
-  handleSelectColumn: () => { },
-  handleExpandNode: () => { },
-  handleColumnHover: () => { },
+  setIsLineageOptionsPanelOpen: () => {},
+  handleSelectColumn: () => {},
+  handleExpandNode: () => {},
+  handleColumnHover: () => {},
   onTableHeaderClick: () => Promise.resolve(),
-  onMouseEnterNode: () => { },
-  onMouseLeaveNode: () => { },
-  updateHoveredEdge: () => { },
-  updateSelectedEdge: () => { },
-  updateGraph: () => { },
+  onMouseEnterNode: () => {},
+  onMouseLeaveNode: () => {},
+  updateHoveredEdge: () => {},
+  updateSelectedEdge: () => {},
+  updateGraph: () => {},
   rootAsset: null,
   isLineageLevelSelectorOpen: false,
-  setIsLineageLevelSelectorOpen: () => { },
-  setLineageOptionsAndRefetch: () => { },
+  setIsLineageLevelSelectorOpen: () => {},
+  setLineageOptionsAndRefetch: () => {},
 });
 
 type Column = {
@@ -148,18 +148,18 @@ type LineageViewProviderProps = {
 
 type LineageFetchType =
   | {
-    type: "asset";
-    data: {
-      nodeId: string;
-    };
-  }
+      type: "asset";
+      data: {
+        nodeId: string;
+      };
+    }
   | {
-    type: "project";
-    data: {
-      branchId: string;
-      filePath: string;
+      type: "project";
+      data: {
+        branchId: string;
+        filePath: string;
+      };
     };
-  };
 
 export function LineageViewProvider({ children }: LineageViewProviderProps) {
   const { setFocusedAsset, setAssetPreview } = useAppContext();
@@ -372,8 +372,6 @@ export function LineageViewProvider({ children }: LineageViewProviderProps) {
       setRootAsset(null);
       return;
     }
-
-    setLineageOptionsAndRefetch(lineageOptions);
   };
   useEffect(onLineageFetchTypeChange, [lineageFetchType]);
 

--- a/frontend/src/app/contexts/LineageView.tsx
+++ b/frontend/src/app/contexts/LineageView.tsx
@@ -333,8 +333,6 @@ export function LineageViewProvider({ children }: LineageViewProviderProps) {
         return;
       }
 
-      console.log("asset_only: ", options.asset_only);
-
       setLineageData((prev) => ({
         ...prev,
         [lineageFetchType.data.filePath]: {

--- a/frontend/src/app/contexts/LineageView.tsx
+++ b/frontend/src/app/contexts/LineageView.tsx
@@ -333,13 +333,15 @@ export function LineageViewProvider({ children }: LineageViewProviderProps) {
         return;
       }
 
+      console.log("asset_only: ", options.asset_only);
+
       setLineageData((prev) => ({
         ...prev,
         [lineageFetchType.data.filePath]: {
           isLoading: true,
           data: null,
           error: null,
-          showColumns: options.asset_only,
+          showColumns: !options.asset_only,
         },
       }));
 
@@ -360,7 +362,7 @@ export function LineageViewProvider({ children }: LineageViewProviderProps) {
           isLoading: false,
           data: data.lineage,
           error: null,
-          showColumns: options.asset_only,
+          showColumns: !options.asset_only,
         },
       }));
     }

--- a/frontend/src/app/editor/[id]/page.tsx
+++ b/frontend/src/app/editor/[id]/page.tsx
@@ -469,7 +469,7 @@ function EditorPageContent() {
                         <TabsContent value="branch">Branches</TabsContent>
                     </Tabs>
                 </Panel> */}
-        <PanelResizeHandle className="bg-transparent   transition-colors" />
+        <PanelResizeHandle className="bg-transparent transition-colors" />
         <Panel>
           <div className="h-full" ref={topBarRef}>
             <FileTabs

--- a/frontend/src/app/settings/api-keys-table.tsx
+++ b/frontend/src/app/settings/api-keys-table.tsx
@@ -1,11 +1,11 @@
 import { Button } from "@/components/ui/button";
 import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from "@/components/ui/table";
 import { Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -24,18 +24,12 @@ export function ApiKeysTable({ apiKeys }: ApiKeysTableProps) {
   const handleSubmit = async () => {
     try {
       setIsSaving(true);
-      const response = await updateSettings({
+      await updateSettings({
         api_keys: {
           openai_api_key: openAIKey,
           anthropic_api_key: anthropicKey,
         },
       });
-
-      if (!response.ok) {
-        console.error("Failed to update API keys");
-      } else {
-        console.log("API keys updated successfully");
-      }
     } catch (error) {
       console.error("Error updating API keys:", error);
     } finally {

--- a/frontend/src/components/editor/bottom-panel.tsx
+++ b/frontend/src/components/editor/bottom-panel.tsx
@@ -87,8 +87,6 @@ export default function BottomPanel({
     activeFile?.node.type === "file" &&
     activeFile.node.name.endsWith(".sql");
 
-    console.log(lineageData[activeFile?.node.path || ""]?.showColumns)
-
   return (
     <Fragment>
       <PanelResizeHandle className="h-1 hover:bg-gray-300 dark:hover:bg-zinc-700 hover:cursor-col-resize transition-colors" />
@@ -199,7 +197,7 @@ export default function BottomPanel({
                 <Switch
                   id="asset-only"
                   checked={
-                    !lineageData[activeFile?.node.path || ""]?.showColumns
+                    lineageData[activeFile?.node.path || ""]?.showColumns
                   }
                   onCheckedChange={(checked) => {
                     setLineageOptionsAndRefetch(

--- a/frontend/src/components/editor/bottom-panel.tsx
+++ b/frontend/src/components/editor/bottom-panel.tsx
@@ -87,6 +87,8 @@ export default function BottomPanel({
     activeFile?.node.type === "file" &&
     activeFile.node.name.endsWith(".sql");
 
+    console.log(lineageData[activeFile?.node.path || ""]?.showColumns)
+
   return (
     <Fragment>
       <PanelResizeHandle className="h-1 hover:bg-gray-300 dark:hover:bg-zinc-700 hover:cursor-col-resize transition-colors" />
@@ -265,11 +267,11 @@ export default function BottomPanel({
                       </div>
                     )}
                   {lineageData?.[activeFile?.node.path || ""] &&
-                    lineageData[activeFile?.node.path || ""].data && (
-                      <LineageView
-                        style={{ height: (bottomPanelHeight ?? 0) - 28 }}
-                      />
-                    )}
+                  lineageData[activeFile?.node.path || ""].data ? (
+                    <LineageView
+                      style={{ height: (bottomPanelHeight ?? 0) - 28 }}
+                    />
+                  ) : null}
                   {lineageData?.[activeFile?.node.path || ""] &&
                     lineageData[activeFile?.node.path || ""].error && (
                       <ErrorMessage

--- a/frontend/src/components/editor/problems-panel/problems-panel.tsx
+++ b/frontend/src/components/editor/problems-panel/problems-panel.tsx
@@ -12,28 +12,30 @@ export default function ProblemsPanel() {
     );
   }
 
-  return checkForProblemsOnEdit ? (
-    problems.loading ? (
+  if (!checkForProblemsOnEdit) {
+    return (
       <div className="flex items-center justify-center h-full">
-        <Loader2 className="animate-spin" />
+        <p>
+          The settings "Check for problems on edit" is disabled. Please enable
+          it to see problems.
+        </p>
       </div>
-    ) : (
-      <div className="p-4">
-        {problems.data.length > 0 ? (
-          problems.data.map((problem) => (
-            <div key={problem.message}>{problem.message}</div>
-          ))
-        ) : (
-          <div>No problems found</div>
-        )}
-      </div>
-    )
-  ) : (
+    );
+  }
+
+  return problems.loading ? (
     <div className="flex items-center justify-center h-full">
-      <p>
-        The settings "Check for problems on edit" is disabled. Please enable it
-        to see problems.
-      </p>
+      <Loader2 className="animate-spin" />
+    </div>
+  ) : (
+    <div className="p-4">
+      {problems.data.length > 0 ? (
+        problems.data.map((problem) => (
+          <div key={problem.message}>{problem.message}</div>
+        ))
+      ) : (
+        <div>No problems found</div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/lineage/ColumnLineage.tsx
+++ b/frontend/src/components/lineage/ColumnLineage.tsx
@@ -1,5 +1,12 @@
 import "@xyflow/react/dist/style.css";
 
+import {
+  Background,
+  Panel,
+  ReactFlow,
+  type ReactFlowInstance,
+  useNodesInitialized,
+} from "@xyflow/react";
 import type React from "react";
 import {
   useContext,
@@ -8,30 +15,23 @@ import {
   useMemo,
   useState,
 } from "react";
-import {
-  ReactFlow,
-  Background,
-  Panel,
-  type ReactFlowInstance,
-  useNodesInitialized,
-} from "@xyflow/react";
 
+import { useFiles } from "@/app/contexts/FilesContext";
+import { LineageViewContext } from "@/app/contexts/LineageView";
+import { Loader2 } from "lucide-react";
+import { useTheme } from "next-themes";
+import { usePathname } from "next/navigation";
+import { useAppContext } from "../../contexts/AppContext";
 import { getColumnLineageForAsset } from "../../lib/lineage";
 import ColumnConnectionEdge from "./ColumnConnectionEdge";
 import ColumnLineageNode from "./ColumnLineageNode";
 import ErrorNode from "./ErrorNode";
-import { LineageViewContext } from "@/app/contexts/LineageView";
-import LoadingNode from "./LoadingNode";
-import buildLineageReactFlow from "./renderLineage";
 import { FilterPanel } from "./FilterPanel";
 import "./lineage.css";
-import { Loader2 } from "lucide-react";
-import { useAppContext } from "../../contexts/AppContext";
 import { LineageControls } from "./LineageControls";
 import LineageOptionsPanel from "./LineageOptionsPanel";
-import { useTheme } from "next-themes";
-import { useFiles } from "@/app/contexts/FilesContext";
-import { usePathname } from "next/navigation";
+import LoadingNode from "./LoadingNode";
+import buildLineageReactFlow from "./renderLineage";
 
 const nodeTypes = {
   custom: ColumnLineageNode,
@@ -79,7 +79,7 @@ const ColumnLineageFlow = () => {
   const isInEditor = pathname.includes("editor");
   const showFilterPanel =
     isInEditor && activeFile
-      ? !lineageData[activeFile.node.path]?.showColumns
+      ? lineageData[activeFile.node.path]?.showColumns
       : true;
 
   const onReactFlowInit = (reactFlowInstance: ReactFlowInstance) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Cancel unnecessary loading of lineage and problems tab when switching tabs, improving performance and user experience.
> 
>   - **Behavior**:
>     - Cancel loading of lineage and problems tab when switching tabs in the editor.
>     - Adjust `showColumns` logic in `LineageViewProvider` to correctly reflect `asset_only` option.
>   - **Frontend**:
>     - Update `LineageViewProvider` in `LineageView.tsx` to handle `asset_only` option correctly.
>     - Modify `BottomPanel` in `bottom-panel.tsx` to toggle column visibility based on `asset_only`.
>     - Adjust `ColumnLineageFlow` in `ColumnLineage.tsx` to reflect changes in lineage data handling.
>   - **Misc**:
>     - Remove unused imports in `project_views.py`.
>     - Fix minor formatting issues in `page.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 6f8e20220148b8e1c0b6190c4cf7d4c242da51fb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->