### PR TITLE
fix job order jumping around

### DIFF
--- a/frontend/src/app/jobs/page.tsx
+++ b/frontend/src/app/jobs/page.tsx
@@ -55,17 +55,14 @@ export default function JobsPage({ searchParams }: JobsPageProps) {
     if (!isMountedRef.current) return;
 
     const sortedJobs = (jobsData?.results || []).sort((a, b) => {
-      if (
-        a.latest_run?.status === "STARTED" &&
-        b.latest_run?.status !== "STARTED"
-      )
-        return -1;
-      if (
-        a.latest_run?.status !== "STARTED" &&
-        b.latest_run?.status === "STARTED"
-      )
-        return 1;
-      return dayjs.utc(a.next_run).diff(dayjs.utc(b.next_run));
+      const dateA = dayjs.utc(a.latest_run?.date_done || 0);
+      const dateB = dayjs.utc(b.latest_run?.date_done || 0);
+
+      const dateDiff = dateB.diff(dateA);
+      if (dateDiff !== 0) {
+        return dateDiff;
+      }
+      return a.id.localeCompare(b.id);
     });
 
     const sortedRuns = (runsData?.results || []).sort((a, b) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes job order in `JobsPage` by sorting jobs by `date_done` and `id`.
> 
>   - **Behavior**:
>     - Fixes job order in `JobsPage` by changing sorting logic.
>     - Sorts jobs by `latest_run.date_done` in descending order, then by `id`.
>   - **Code**:
>     - Removes status-based sorting logic for jobs.
>     - Updates `sortedJobs` function in `page.tsx` to use `date_done` and `id` for sorting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for e996aade9ffc6c6a18497a7a849f3bdb46f7e330. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->