### PR TITLE
show job link in run

### DIFF
--- a/frontend/src/app/jobs/[jobId]/run/[runId]/page.tsx
+++ b/frontend/src/app/jobs/[jobId]/run/[runId]/page.tsx
@@ -94,9 +94,7 @@ export default function JobRunPage({ params }: JobRunPageProps) {
   }
 
   return (
-    <FullWidthPageLayout
-      title={`${job.name} / Run ${truncateUuid(run.task_id)}`}
-    >
+    <FullWidthPageLayout title={`Run ${truncateUuid(run.task_id)}`}>
       <JobRunIdPage run={run} job={job} />
     </FullWidthPageLayout>
   );

--- a/frontend/src/components/jobs/runs/run-details.tsx
+++ b/frontend/src/components/jobs/runs/run-details.tsx
@@ -3,6 +3,7 @@ import StatusIcon from "@/components/jobs/status-icon";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import dayjs from "dayjs";
 import { capitalize } from "lodash";
+import Link from "next/link";
 
 type RunDetailsProps = {
   run: Run;
@@ -17,14 +18,32 @@ export default function RunDetails({ run, job }: RunDetailsProps) {
       <CardHeader>
         <CardTitle>Run Details</CardTitle>
       </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="grid grid-cols-2 gap-4">
+      <CardContent>
+        <div className="grid grid-cols-3 gap-4">
           <div>
             <p className="text-sm font-medium text-muted-foreground">Status</p>
             <div className="flex items-center gap-2">
               <StatusIcon status={run.status} />
               <p className="text-sm">{capitalize(run.status)}</p>
             </div>
+          </div>
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">Job</p>
+            <Link href={`/jobs/${job.id}`} className="w-fit">
+              <p className="text-sm underline underline-offset-2 hover:text-primary">
+                {job.name}
+              </p>
+            </Link>
+          </div>
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">
+              Next Run Date
+            </p>
+            <p className="text-sm">
+              {job.next_run
+                ? dayjs(job.next_run).format("MMM D, YYYY h:mm A")
+                : "N/A"}
+            </p>
           </div>
           <div>
             <p className="text-sm font-medium text-muted-foreground">
@@ -45,9 +64,7 @@ export default function RunDetails({ run, job }: RunDetailsProps) {
             </p>
           </div>
           <div>
-            <p className="text-sm font-medium text-muted-foreground">
-              Trigger
-            </p>
+            <p className="text-sm font-medium text-muted-foreground">Trigger</p>
             <p className="text-sm">{trigger}</p>
           </div>
         </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a job link to the run details page and updates the layout to accommodate it.
> 
>   - **Behavior**:
>     - Adds a link to the job details in `run-details.tsx`, allowing users to navigate to the job page.
>     - Removes job name from the page title in `page.tsx`, now only showing the run ID.
>   - **Layout**:
>     - Changes grid layout in `run-details.tsx` from 2 to 3 columns to fit the new job link.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for a395e7e6f12c0be2f76eefc8f3aec7418202140d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->