### PR TITLE
Remove extraneous breakpoint

### DIFF
--- a/backend/app/core/e2e.py
+++ b/backend/app/core/e2e.py
@@ -39,6 +39,7 @@ from app.utils.database import pg_delete_and_upsert
 from vinyl.lib.errors import VinylError, VinylErrorType
 from vinyl.lib.schema import VinylSchema
 from vinyl.lib.sqlast import SQLAstNode
+from vinyl.lib.utils.graph import nx_remove_node_and_reconnect
 
 _STR_JOIN_HELPER = "_____"
 
@@ -1042,7 +1043,6 @@ class DataHubDBParser:
                 try:
                     get_schema_field_urn(node)
                 except (InvalidUrnError, AssertionError):
-                    breakpoint()
                     nx_remove_node_and_reconnect(graph_it, node, preserve_ntype=True)
                     error = AssetError(
                         asset=asset,

--- a/backend/vinyl/lib/dbt.py
+++ b/backend/vinyl/lib/dbt.py
@@ -2,6 +2,7 @@
 import os
 import re
 import select
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -13,6 +14,7 @@ from typing import Any, Callable, Generator
 import orjson
 import yaml
 from dbt_extractor import ExtractionError, py_extract_from_source
+from mpire import WorkerPool
 
 from vinyl.lib.dbt_methods import (
     DBTArgs,
@@ -310,7 +312,8 @@ class DBTProject(object):
 
     @patch_json_with_orjson
     @patch_yaml_with_libyaml
-    def dbt_runner(self, command: list[str]) -> tuple[str, str, bool]:
+    def _dbt_runner_helper(self, command_str: str) -> tuple[str, str, bool]:
+        command = shlex.split(command_str)
         env, cwd = self._dbt_cli_env(full_os_env=False)
 
         try:
@@ -357,6 +360,16 @@ class DBTProject(object):
             ## restore original directory if everything fails.
             if not current_dir or current_dir != orig_cwd:
                 os.chdir(orig_cwd)
+
+    def dbt_runner(
+        self, command: list[str], isolate_with_fork: bool = True
+    ) -> tuple[str, str, bool]:
+        command_str = " ".join(command)
+        if isolate_with_fork:
+            with WorkerPool(n_jobs=1) as pool:
+                return pool.map(self._dbt_runner_helper, [command_str])[0]
+        else:
+            return self._dbt_runner_helper(command_str)
 
     def _dbt_cli_env(self, full_os_env: bool = True):
         env = self.env_vars.copy()
@@ -502,7 +515,7 @@ class DBTProject(object):
         cli_args: list[str] | None = None,
         write_json: bool = False,
         dbt_cache: bool = False,
-        force_terminal: bool = True,
+        force_terminal: bool = False,
         defer: bool = False,
         defer_selection: bool = True,
     ) -> tuple[str, str, bool]:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove extraneous `breakpoint()` from `get_db_cll()` in `e2e.py`.
> 
>   - **Misc**:
>     - Remove extraneous `breakpoint()` from `get_db_cll()` in `e2e.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 8a8b377c7ac488dfd385752c2e9bfd42aac0d2fd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->