### PR TITLE
fix sidebar booleans to widths

### DIFF
--- a/frontend/src/app/contexts/LayoutContext.tsx
+++ b/frontend/src/app/contexts/LayoutContext.tsx
@@ -9,13 +9,16 @@ import {
 } from "react";
 
 type LayoutContextType = {
-  sidebarLeftShown: boolean;
-  setSidebarLeftShown: (shown: boolean) => void;
-  sidebarRightShown: boolean;
-  setSidebarRightShown: (shown: boolean) => void;
-  bottomPanelShown: boolean;
-  setBottomPanelShown: (shown: boolean) => void;
+  sidebarLeftWidth: number;
+  setSidebarLeftWidth: React.Dispatch<React.SetStateAction<number>>;
+  sidebarRightWidth: number;
+  setSidebarRightWidth: React.Dispatch<React.SetStateAction<number>>;
+  bottomPanelWidth: number;
+  setBottomPanelWidth: React.Dispatch<React.SetStateAction<number>>;
   appSidebarCollapsed: boolean;
+  isSidebarLeftCollapsed: boolean;
+  isSidebarRightCollapsed: boolean;
+  isBottomPanelCollapsed: boolean;
 };
 
 const LayoutContext = createContext<LayoutContextType | undefined>(undefined);
@@ -31,11 +34,15 @@ export const useLayoutContext = () => {
 export const LayoutProvider: React.FC<{ children: ReactNode }> = ({
   children,
 }) => {
-  const [sidebarLeftShown, setSidebarLeftShown] = useState(true);
-  const [bottomPanelShown, setBottomPanelShown] = useState(true);
-  const [sidebarRightShown, setSidebarRightShown] = useState(false);
+  const [sidebarLeftWidth, setSidebarLeftWidth] = useState<number>(20);
+  const [sidebarRightWidth, setSidebarRightWidth] = useState<number>(20);
+  const [bottomPanelWidth, setBottomPanelWidth] = useState<number>(20);
   const [appSidebarCollapsed, setAppSidebarCollapsed] = useState(false);
   const pathName = usePathname();
+
+  const isSidebarLeftCollapsed = sidebarLeftWidth === 0;
+  const isSidebarRightCollapsed = sidebarRightWidth === 0;
+  const isBottomPanelCollapsed = bottomPanelWidth === 0;
 
   useEffect(() => {
     setAppSidebarCollapsed(
@@ -44,13 +51,16 @@ export const LayoutProvider: React.FC<{ children: ReactNode }> = ({
   }, [pathName]);
 
   const value = {
-    sidebarLeftShown,
-    setSidebarLeftShown,
-    sidebarRightShown,
-    setSidebarRightShown,
-    bottomPanelShown,
-    setBottomPanelShown,
+    sidebarLeftWidth,
+    setSidebarLeftWidth,
+    sidebarRightWidth,
+    setSidebarRightWidth,
+    bottomPanelWidth,
+    setBottomPanelWidth,
     appSidebarCollapsed,
+    isSidebarLeftCollapsed,
+    isSidebarRightCollapsed,
+    isBottomPanelCollapsed,
   };
 
   return (

--- a/frontend/src/components/editor/bottom-panel.tsx
+++ b/frontend/src/components/editor/bottom-panel.tsx
@@ -85,7 +85,7 @@ export default function BottomPanel({
     setAiCompiledSql,
   } = useAISidebar();
 
-  const { sidebarRightShown, setSidebarRightShown } = useLayoutContext();
+  const { isSidebarRightCollapsed, setSidebarRightWidth } = useLayoutContext();
 
   const [activeTab, setActiveTab] = useBottomPanelTabs({
     branchId: branchId || "",
@@ -104,8 +104,8 @@ export default function BottomPanel({
         table,
         file_name: queryPreviewData.file_name,
       });
-      if (!sidebarRightShown) {
-        setSidebarRightShown(true);
+      if (isSidebarRightCollapsed) {
+        setSidebarRightWidth(20);
       }
     }
   };
@@ -116,8 +116,8 @@ export default function BottomPanel({
         compiled_query: compiledSql.sql,
         file_name: compiledSql.file_name,
       });
-      if (!sidebarRightShown) {
-        setSidebarRightShown(true);
+      if (isSidebarRightCollapsed) {
+        setSidebarRightWidth(20);
       }
     }
   };

--- a/frontend/src/components/editor/editor-content.tsx
+++ b/frontend/src/components/editor/editor-content.tsx
@@ -13,7 +13,7 @@ import { useAISidebar } from "./ai/ai-sidebar-context";
 
 export default function EditorContent({ containerWidth }: { containerWidth: number }) {
   const { setAiCustomSelections } = useAISidebar();
-  const { sidebarRightShown, setSidebarRightShown } = useLayoutContext();
+  const { isSidebarRightCollapsed, setSidebarRightWidth } = useLayoutContext();
   const { resolvedTheme } = useTheme();
   const {
     activeFile,
@@ -48,8 +48,8 @@ export default function EditorContent({ containerWidth }: { containerWidth: numb
       ...(prev || []),
       { selection: selectedText, start_line: startLine, end_line: endLine, file_name: fileName },
     ]);
-    if (!sidebarRightShown) {
-      setSidebarRightShown(true);
+    if (isSidebarRightCollapsed) {
+      setSidebarRightWidth(20);
     }
   };
 

--- a/frontend/src/components/editor/editor-top-bar.tsx
+++ b/frontend/src/components/editor/editor-top-bar.tsx
@@ -43,12 +43,12 @@ const clearTurntableCache = () => {
 
 const EditorTopBar = () => {
   const {
-    sidebarLeftShown,
-    setSidebarLeftShown,
-    bottomPanelShown,
-    setBottomPanelShown,
-    sidebarRightShown,
-    setSidebarRightShown,
+    isSidebarLeftCollapsed,
+    setSidebarLeftWidth,
+    isBottomPanelCollapsed,
+    setBottomPanelWidth,
+    isSidebarRightCollapsed,
+    setSidebarRightWidth,
   } = useLayoutContext();
   const router = useRouter();
   const { user, logout } = useSession();
@@ -72,12 +72,14 @@ const EditorTopBar = () => {
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
-              onClick={() => setSidebarLeftShown(!sidebarLeftShown)}
+              onClick={() =>
+                setSidebarLeftWidth(isSidebarLeftCollapsed ? 20 : 0)
+              }
               variant="ghost"
               className="hover:bg-white"
               size="icon"
             >
-              {sidebarLeftShown ? (
+              {isSidebarLeftCollapsed ? (
                 <PanelLeftClose className="h-4 w-4" />
               ) : (
                 <PanelLeft className="h-4 w-4" />
@@ -130,12 +132,14 @@ const EditorTopBar = () => {
         <Tooltip delayDuration={300}>
           <TooltipTrigger asChild>
             <Button
-              onClick={() => setBottomPanelShown(!bottomPanelShown)}
+              onClick={() =>
+                setBottomPanelWidth(isBottomPanelCollapsed ? 20 : 0)
+              }
               variant="ghost"
               className="hover:bg-white"
               size="icon"
             >
-              {bottomPanelShown ? (
+              {isBottomPanelCollapsed ? (
                 <PanelBottomClose className="h-4 w-4" />
               ) : (
                 <PanelBottom className="h-4 w-4" />
@@ -149,7 +153,7 @@ const EditorTopBar = () => {
         <Tooltip delayDuration={300}>
           <TooltipTrigger asChild>
             <Button
-              onClick={() => setSidebarRightShown(!sidebarRightShown)}
+              onClick={() => setSidebarRightWidth(isSidebarRightCollapsed ? 20 : 0)}
               variant="ghost"
               className="hover:bg-white"
               size="icon"

--- a/frontend/src/components/editor/problems-panel/problems-btn-group.tsx
+++ b/frontend/src/components/editor/problems-panel/problems-btn-group.tsx
@@ -11,7 +11,7 @@ import { useAISidebar } from "../ai/ai-sidebar-context";
 
 export default function ProblemsBtnGroup() {
   const { problems, activeFile } = useFiles();
-  const { sidebarRightShown, setSidebarRightShown } = useLayoutContext();
+  const { isSidebarRightCollapsed, setSidebarRightWidth } = useLayoutContext();
   const { setAiFileProblems, aiFileProblems} = useAISidebar();
 
   const showAddProblemsToChatButton =
@@ -23,8 +23,8 @@ export default function ProblemsBtnGroup() {
       file_name: activeFile?.node.name || "",
     });
 
-    if (!sidebarRightShown) {
-      setSidebarRightShown(true);
+    if (isSidebarRightCollapsed) {
+      setSidebarRightWidth(20);
     }
   };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Convert sidebar and panel state management from boolean visibility to numeric width in `LayoutContext` and update related components.
> 
>   - **Behavior**:
>     - Change sidebar and panel state from boolean visibility to numeric width in `LayoutContext`.
>     - Update keyboard shortcuts in `EditorPageContent` to toggle widths instead of visibility.
>     - Modify `BottomPanel`, `EditorContent`, `EditorTopBar`, and `ProblemsBtnGroup` to use width-based logic.
>   - **State Management**:
>     - Add `sidebarLeftWidth`, `sidebarRightWidth`, `bottomPanelWidth` to `LayoutContext`.
>     - Add `isSidebarLeftCollapsed`, `isSidebarRightCollapsed`, `isBottomPanelCollapsed` to `LayoutContext`.
>   - **UI Components**:
>     - Update `Panel` components in `page.tsx` to use width-based logic.
>     - Adjust `BottomPanel` and `EditorContent` to handle width changes.
>     - Modify `EditorTopBar` buttons to toggle widths.
>     - Update `ProblemsBtnGroup` to expand sidebar when adding problems to chat.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 23de486fb66bf8331076d9ffbb06530dd0a97c45. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->