### PR TITLE
fix edit history

### DIFF
--- a/frontend/src/components/editor/ai/ai-message-box.tsx
+++ b/frontend/src/components/editor/ai/ai-message-box.tsx
@@ -25,6 +25,7 @@ export default function AiMessageBox({
   const containerRef = useRef<HTMLDivElement>(null);
 
   const handleEdit = () => {
+    setInput(message.content);
     setIsEditing(true);
   };
 
@@ -63,7 +64,6 @@ export default function AiMessageBox({
   return (
     <div
       ref={containerRef}
-      key={message.id}
       className={`${
         message.role === "user"
           ? "bg-background p-2 rounded-md border border-transparent hover:border-muted-foreground"
@@ -79,6 +79,8 @@ export default function AiMessageBox({
           handleSubmit={handleSubmit}
           stopWebSocket={stopWebSocket}
           autoFocus={true}
+          input={input}
+          setInput={setInput}
         />
       ) : message.role === "user" ? (
         <p className="whitespace-pre-wrap">{message.content}</p>

--- a/frontend/src/components/editor/ai/ai-sidebar.tsx
+++ b/frontend/src/components/editor/ai/ai-sidebar.tsx
@@ -140,13 +140,23 @@ export default function AiSidebarChat() {
   };
 
   const handleEditMessage = (index: number, newContent: string) => {
-    const newMessageHistory = messageHistory.slice(0, index + 1);
+    const newMessageHistory = [...messageHistory];
+
     newMessageHistory[index] = {
       ...newMessageHistory[index],
       content: newContent,
     };
+
+    if (
+      newMessageHistory[index + 1] &&
+      newMessageHistory[index + 1].role === "assistant"
+    ) {
+      newMessageHistory.splice(index + 1);
+    } else {
+      newMessageHistory.splice(index + 1);
+    }
+
     setMessageHistory(newMessageHistory);
-    setMessageHistory((prev) => prev.slice(0, index + 1));
     stopWebSocket();
     handleSubmit(null, newMessageHistory);
   };

--- a/frontend/src/components/editor/ai/chat-controls.tsx
+++ b/frontend/src/components/editor/ai/chat-controls.tsx
@@ -26,6 +26,8 @@ interface ChatControlsProps {
   handleSubmit: (e: React.FormEvent) => void;
   stopWebSocket: () => void;
   autoFocus?: boolean;
+  input?: string;
+  setInput?: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export default function ChatControls({
@@ -33,19 +35,21 @@ export default function ChatControls({
   handleSubmit,
   stopWebSocket,
   autoFocus = false,
+  input: propInput,
+  setInput: propSetInput,
 }: ChatControlsProps) {
   const {
-    input,
-    setInput,
+    input: contextInput,
+    setInput: contextSetInput,
     isLoading,
+    selectedModel,
+    setSelectedModel,
     aiActiveFile,
     setAiActiveFile,
     aiLineageContext,
     setAiLineageContext,
     contextFiles,
     setContextFiles,
-    selectedModel,
-    setSelectedModel,
     aiContextPreview,
     setAiContextPreview,
     aiCompiledSql,
@@ -55,6 +59,10 @@ export default function ChatControls({
     aiCustomSelections,
     setAiCustomSelections,
   } = useAISidebar();
+
+  // Use props if provided, otherwise use context
+  const input = propInput !== undefined ? propInput : contextInput;
+  const setInput = propSetInput !== undefined ? propSetInput : contextSetInput;
 
   const [isFileExplorerOpen, setIsFileExplorerOpen] = useState(false);
   const numberOfLineageFiles = aiLineageContext?.assets?.length || 0;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes edit history in AI chat components by updating message handling and input state management.
> 
>   - **Behavior**:
>     - Fixes edit history in `AiSidebarChat` by updating `handleEditMessage()` to correctly splice message history when editing.
>     - Ensures `AiMessageBox` sets input state with `setInput()` when editing starts.
>   - **Props and State Management**:
>     - Adds `input` and `setInput` props to `ChatControls` and `AiMessageBox` to manage input state.
>     - Uses props for `input` and `setInput` in `ChatControls` if provided, otherwise defaults to context values.
>   - **Misc**:
>     - Removes unnecessary `key` prop from `div` in `AiMessageBox`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 287ca693ad51d2489608a4d9de8823ab9b493b9b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->