### PR TITLE
light mode chat contrast

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -130,8 +130,19 @@ html {
   overflow: hidden;
 }
 
-pre {
+.dark pre {
   background: #0d0d0d;
+  color: #fff;
+}
+
+.prose :where(pre):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  background: white;
+  padding: 4px 12px;
+  color: #0d0d0d;
+}
+
+pre {
+  background: #f4f4f5;
   border-radius: 0.5rem;
   color: #fff;
   font-family: "JetBrainsMono", monospace;

--- a/frontend/src/components/editor/ai/ai-message-box.tsx
+++ b/frontend/src/components/editor/ai/ai-message-box.tsx
@@ -66,7 +66,7 @@ export default function AiMessageBox({
       key={message.id}
       className={`${
         message.role === "user"
-          ? "bg-background p-2 rounded-md border border-transparent hover:border-muted-foreground"
+          ? "bg-white dark:bg-background p-2 rounded-md border border-transparent hover:border-muted-foreground"
           : isLastMessage
             ? "p-1 mb-96"
             : "p-1 mb-8"

--- a/frontend/src/components/editor/ai/chat-controls.tsx
+++ b/frontend/src/components/editor/ai/chat-controls.tsx
@@ -115,7 +115,7 @@ export default function ChatControls({
           </Button>
         </div>
       )}
-      <div className="flex flex-col bg-background rounded-md p-2 gap-2">
+      <div className="flex flex-col bg-white dark:bg-background rounded-md p-2 gap-2">
         <div className="flex gap-1 flex-wrap min-h-6">
           <div
             className="hover:bg-muted rounded-md px-0.5 cursor-pointer border flex items-center justify-center relative"

--- a/frontend/src/components/editor/ai/response-display.tsx
+++ b/frontend/src/components/editor/ai/response-display.tsx
@@ -113,7 +113,9 @@ export default function ResponseDisplay({ content }: ResponseDisplayProps) {
   }, [throttledFile]);
 
   useEffect(() => {
-    throttledSetFile(activeFile);
+    if (JSON.stringify(activeFile) !== JSON.stringify(throttledFile)) {
+      throttledSetFile(activeFile);
+    }
   }, [activeFile]);
 
   const handleApply = (code: string) => {
@@ -153,6 +155,7 @@ export default function ResponseDisplay({ content }: ResponseDisplayProps) {
                   <Button
                     variant="outline"
                     size="sm"
+                    className="text-gray-600 dark:text-gray-200"
                     onClick={() => copy(codeString)}
                   >
                     <Copy className="w-4 h-4 mr-2" />
@@ -162,6 +165,7 @@ export default function ResponseDisplay({ content }: ResponseDisplayProps) {
                     variant="outline"
                     size="sm"
                     disabled={isApplying}
+                    className="text-gray-600 dark:text-gray-200"
                     onClick={() => handleApply(codeString)}
                   >
                     {isApplying ? "Applying" : "Apply"}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves light mode chat contrast by updating CSS and refining component logic in `globals.css`, `ai-message-box.tsx`, and `response-display.tsx`.
> 
>   - **CSS Changes**:
>     - Updated `.dark pre` and `.prose :where(pre)` in `globals.css` for improved light mode contrast.
>     - Changed `bg-white dark:bg-background` for user messages in `ai-message-box.tsx` and `chat-controls.tsx`.
>   - **Component Updates**:
>     - Added condition in `useEffect` in `response-display.tsx` to prevent unnecessary state updates.
>     - Updated button text color in `response-display.tsx` for better light mode contrast.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 1541302cb0251da02852e1957b51c03e0817addb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->