### PR TITLE
support inexact hostnames

### DIFF
--- a/backend/app/management/commands/suspend_worker.py
+++ b/backend/app/management/commands/suspend_worker.py
@@ -144,9 +144,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--hostname", type=str, required=False)
         parser.add_argument("--max-wait", type=int, required=False, default=3600)
-        parser.add_argument(
-            "--interval", type=int, required=False, default=POLLING_INTERVAL
-        )
+        parser.add_argument("--interval", type=int, required=False, default=1)
         parser.add_argument(
             "--excluded-queues",
             type=str,

--- a/backend/app/management/commands/suspend_worker.py
+++ b/backend/app/management/commands/suspend_worker.py
@@ -5,7 +5,7 @@ import time
 from celery import current_app
 from django.core.management.base import BaseCommand
 
-POLLING_INTERVAL = 5
+POLLING_INTERVAL = 1
 MAX_POLLING_ATTEMPTS = 10
 
 
@@ -74,15 +74,21 @@ def ensure_active_workers(
     hostname: str | None = None,
     excluded_queues: list[str] = [],
     mandate_on_worker: bool = True,
+    inexact_hostname: bool = False,
 ) -> bool:
-    active_queues, active_workers, _ = get_active_queues(
-        excluded_queues=excluded_queues
+    _, active_workers, _ = get_active_queues(
+        excluded_queues=excluded_queues,
     )
 
     # hostname is in active_workers
     hostnames = [worker.split("@")[1] for worker in active_workers]
-    if hostname is not None and hostname not in hostnames:
-        return False
+    if hostname is not None:
+        if inexact_hostname:
+            if all(hostname not in h for h in hostnames):
+                return False
+        else:
+            if hostname not in hostnames:
+                return False
 
     # there are at least two active workers
     if mandate_on_worker and len(hostnames) < 2:
@@ -92,21 +98,29 @@ def ensure_active_workers(
 
 
 def get_relevant_workers(
-    active_workers: set[str], hostname: str | None = None
+    active_workers: set[str],
+    hostname: str | None = None,
+    inexact_hostname: bool = False,
 ) -> list[str]:
     if hostname is None:
         return list(active_workers)
-    return [worker for worker in active_workers if worker.split("@")[1] == hostname]
+    if inexact_hostname:
+        return [worker for worker in active_workers if hostname in worker.split("@")[1]]
+    return [worker for worker in active_workers if hostname == worker.split("@")[1]]
 
 
 def cancel_consumer(
-    hostname: str | None = None, excluded_queues: list[str] = []
+    hostname: str | None = None,
+    excluded_queues: list[str] = [],
+    inexact_hostname: bool = False,
 ) -> list[str]:
-    active_queues, active_workers, worker_queue_map = get_active_queues(
-        excluded_queues=excluded_queues
+    _, active_workers, worker_queue_map = get_active_queues(
+        excluded_queues=excluded_queues,
     )
     relevant_workers = get_relevant_workers(
-        active_workers=active_workers, hostname=hostname
+        active_workers=active_workers,
+        hostname=hostname,
+        inexact_hostname=inexact_hostname,
     )
     for worker in relevant_workers:
         for queue in worker_queue_map[worker]:
@@ -131,6 +145,9 @@ class Command(BaseCommand):
         parser.add_argument("--hostname", type=str, required=False)
         parser.add_argument("--max-wait", type=int, required=False, default=3600)
         parser.add_argument(
+            "--interval", type=int, required=False, default=POLLING_INTERVAL
+        )
+        parser.add_argument(
             "--excluded-queues",
             type=str,
             nargs="+",
@@ -143,23 +160,40 @@ class Command(BaseCommand):
             required=False,
             default=False,
         )
+        parser.add_argument(
+            "--inexact-hostname",
+            action="store_true",
+            required=False,
+            default=False,
+        )
 
     def handle(self, *args, **options):
         hostname = options["hostname"]
         max_wait = options["max_wait"]
         excluded_queues = options["excluded_queues"]
         test_mode = options["test_mode"]
+        inexact_hostname = options["inexact_hostname"]
+        interval = options["interval"]
 
         # ensure the worker we want to suspend is running and there's at least one other worker running
-        poller()(ensure_active_workers)(
-            hostname, excluded_queues, mandate_on_worker=not test_mode
+        poller(max_attempts=2)(ensure_active_workers)(
+            hostname,
+            excluded_queues,
+            mandate_on_worker=not test_mode,
+            inexact_hostname=inexact_hostname,
         )
 
         # prevent the worker from being scheduled
-        relevant_workers = cancel_consumer(hostname, excluded_queues)
+        relevant_workers = cancel_consumer(
+            hostname,
+            excluded_queues,
+            inexact_hostname=inexact_hostname,
+        )
 
         # ensure there are no active tasks on suspended worker
-        active_tasks_poller = poller(interval=5, max_attempts=max_wait // 5)
+        active_tasks_poller = poller(
+            interval=interval, max_attempts=max_wait // interval
+        )
         polled = active_tasks_poller(ensure_no_active_tasks)(relevant_workers)
         if test_mode:
             return str(polled)

--- a/backend/app/management/commands/tests/test_suspend_worker.py
+++ b/backend/app/management/commands/tests/test_suspend_worker.py
@@ -8,22 +8,36 @@ from app.management.commands.suspend_worker import get_active_queues
 from app.workflows.utils import long_running_task
 
 
-# test different task durations to ensure shutdown is happening after the task is done
-# don't resume worker for shortest test. For some reason, doesn't pass for github actions.
-@pytest.mark.parametrize("duration", [4, 9, 14])
-def test_suspend_worker(custom_celery, test_queue_name, test_worker_name, duration):
+def setup_worker(custom_celery, test_queue_name, test_worker_name, duration):
     res = long_running_task.si(duration=duration).apply_async()
-    active_queues, active_workers, _ = get_active_queues()
+    active_queues, _, _ = get_active_queues()
     assert test_queue_name in active_queues
     excluded_queues = [q for q in active_queues if q != test_queue_name]
     hostname = test_worker_name.split("@")[1]
+    return res, active_queues, excluded_queues, hostname
+
+
+# test different task durations to ensure shutdown is happening after the task is done
+# don't resume worker for shortest test. For some reason, doesn't pass for github actions.
+@pytest.mark.parametrize(
+    "duration,inexact_hostname", [(4, False), (9, False), (14, False), (4, True)]
+)
+def test_suspend_worker(
+    custom_celery, test_queue_name, test_worker_name, duration, inexact_hostname
+):
+    res, active_queues, excluded_queues, hostname = setup_worker(
+        custom_celery, test_queue_name, test_worker_name, duration
+    )
+    interval = 5
     called = call_command(
         "suspend_worker",
         excluded_queues=excluded_queues,
         test_mode=True,
-        hostname=hostname,
+        hostname=hostname[:-2] if inexact_hostname else hostname,
+        inexact_hostname=inexact_hostname,
+        interval=interval,
     )
-    assert called == str(math.ceil(duration / 5))
+    assert called == str(math.ceil(duration / interval))
     assert res.get()
 
     # resume worker
@@ -31,3 +45,17 @@ def test_suspend_worker(custom_celery, test_queue_name, test_worker_name, durati
     time.sleep(1)
     active_queues, _, _ = get_active_queues()
     assert test_queue_name in active_queues
+
+
+def test_suspend_worker_fail_command(custom_celery, test_queue_name, test_worker_name):
+    res, active_queues, excluded_queues, hostname = setup_worker(
+        custom_celery, test_queue_name, test_worker_name, 4
+    )
+    with pytest.raises(TimeoutError):
+        call_command(
+            "suspend_worker",
+            excluded_queues=excluded_queues,
+            test_mode=True,
+            hostname=hostname[:-2],
+            inexact_hostname=False,
+        )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for inexact hostnames in worker management commands with new `inexact_hostname` parameter and tests.
> 
>   - **Behavior**:
>     - Add `inexact_hostname` parameter to `add_consumer()`, `cancel_consumer()`, `ensure_active_workers()`, and `get_relevant_workers()` to support partial hostname matching.
>     - Update `resume_worker.py` and `suspend_worker.py` to accept `--inexact-hostname` argument.
>     - Reduce `POLLING_INTERVAL` from 5 to 1 in `suspend_worker.py` for faster operations.
>   - **Tests**:
>     - Add `inexact_hostname` test cases in `test_suspend_worker.py` to verify partial hostname matching.
>     - Add `test_suspend_worker_fail_command()` to test failure when `inexact_hostname` is false and hostname is partial.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=turntable-so%2Fturntable&utm_source=github&utm_medium=referral)<sup> for 9ea3c9001f30a7a793b7a15cac854f1cdf92e7b6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->